### PR TITLE
[#17806] docs: add adr for ignoring missing includes

### DIFF
--- a/adr/2026-06-29-ignore-missing-storefront-includes-in-production.md
+++ b/adr/2026-06-29-ignore-missing-storefront-includes-in-production.md
@@ -1,0 +1,70 @@
+---
+title: Ignore missing storefront includes in production
+date: 2026-06-29
+area: storefront
+tags: [storefront, twig, template-rendering, saas]
+---
+
+## Context
+
+Storefront templates can include other Twig templates with `sw_include`. When the referenced template does not exist, Twig currently throws an exception. In the storefront this can render an error page for the whole request.
+
+This is useful during development because missing templates usually indicate a broken theme, app, or extension integration. Developers should see the error immediately and fix the template reference.
+
+In production, the same behavior can reduce shop availability. A single missing include from an installed extension can break the full page instead of rendering the rest of the storefront. This is especially relevant for Shopware SaaS, where platform availability and blast-radius reduction are more important than failing the full storefront request for an optional template include.
+
+Twig already supports `ignore missing` for includes. The proposal is to make this behavior the default for `sw_include` in production in the next major version, while keeping strict failures in development.
+
+Affected technical domains:
+
+* Storefront Twig rendering: `sw_include` needs environment-aware default behavior for missing templates.
+* Extension and theme development: broken template references should still be visible in development.
+* Operations and observability: production shops should stay available, but missing includes must still be detectable.
+* Configuration: projects must be able to keep the current strict production behavior if they depend on it.
+
+## Decision
+
+This ADR proposes the following behavior for the next major version:
+
+* In `APP_ENV=prod`, `sw_include` should ignore missing templates by default.
+* In `APP_ENV=dev`, `sw_include` should keep throwing an exception for missing templates.
+* Projects should have a configuration option to keep strict production behavior and still throw an exception when a storefront include is missing.
+* Explicit `ignore missing` usage in templates remains valid and keeps its current meaning.
+
+The default behavior should be equivalent to adding Twig's `ignore missing` option to `sw_include` calls in production only. Development and test environments should stay strict unless configured otherwise.
+
+The configuration should be global for storefront rendering, not a per-template migration requirement. This avoids requiring all existing templates to be changed and makes the new production behavior predictable.
+
+Example behavior:
+
+```twig
+{% sw_include '@Storefront/storefront/component/example.html.twig' %}
+```
+
+Proposed result:
+
+* `APP_ENV=dev`: throw an exception when the template is missing.
+* `APP_ENV=prod`: render without the missing include by default.
+* `APP_ENV=prod` with strict include configuration enabled: throw an exception when the template is missing.
+
+Possible configuration shape:
+
+```yaml
+storefront:
+    twig:
+        strict_missing_includes: true
+```
+
+The exact configuration name is not part of this ADR and should be finalized during implementation.
+
+## Consequences
+
+Production storefronts become more resilient against broken optional template includes from extensions, apps, or themes. A missing include no longer needs to break the whole shop by default.
+
+Extension and theme developers still receive immediate feedback in development because `APP_ENV=dev` keeps throwing exceptions. This keeps the local developer experience strict and prevents missing templates from being silently ignored while building or testing integrations.
+
+Projects that intentionally rely on strict production failures can opt in to the current behavior through configuration. This is important for self-hosted projects, CI-like production checks, and teams that prefer fail-fast behavior over partial storefront rendering.
+
+The production default can hide visible storefront fragments when a template is missing. Therefore the implementation should make missing includes observable, for example by logging the missing template with enough context to identify the caller and affected sales channel.
+
+This is a behavioral change and should only become the default in the next major version. It needs release documentation and migration guidance explaining the new default and the strict production configuration option.


### PR DESCRIPTION
> Mirror of an upstream pull request, opened for automated review. **Do not merge.**

|  |  |
|---|---|
| Upstream | https://github.com/shopware/shopware/pull/17806 |
| Author | `@bneumann97` |
| Base | `trunk` at merge-base `3b02c7738678` |
| Head | `445a67d47896` |

---

### Original description

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Missing sw_include templates currently throw an exception and can render an error page for the whole storefront request. In production, this means a single broken extension, app, or theme include can break the entire shop page.
For Shopware SaaS, this increases the blast radius of extension errors and can reduce shop availability. We want to discuss making production storefront rendering more resilient while keeping strict feedback for developers.

### 2. What does this change do, exactly?

This adds an ADR proposal to make missing sw_include templates ignored by default in APP_ENV=prod in the next major version, equivalent to Twig’s ignore missing behavior.
The proposal keeps APP_ENV=dev strict, so missing templates still throw exceptions during development. It also proposes a configuration option for projects that want to keep the current strict production behavior and still fail when an include is missing.

### 5. Checklist

- [x] I have written or adjusted the documentation according to my changes
- [x] I have read the contribution requirements and fulfilled them



<!-- shopware-pr-mirror: upstream=shopware/shopware pr=17806 -->

