### PR TITLE
[#19008] fix(checkout): equalize failed login timing to prevent customer enumeration

### DIFF
--- a/src/Core/Checkout/Customer/SalesChannel/AccountService.php
+++ b/src/Core/Checkout/Customer/SalesChannel/AccountService.php
@@ -37,6 +37,11 @@ class AccountService
     use CheckPasswordLengthTrait;
 
     /**
+     * Bcrypt hash of a static dummy password used to equalize timing when the login cannot succeed.
+     */
+    private const DUMMY_PASSWORD_HASH = '$2y$12$PVcA5R6ri9kS.7FnFUBRIOLwqU//bCicx5RFxwecAAccbmZ7V7PKu';
+
+    /**
      * @internal
      *
      * @param EntityRepository<CustomerCollection> $customerRepository
@@ -124,11 +129,17 @@ class AccountService
         try {
             $customer = $this->getCustomerByEmail($email, $context);
         } catch (CustomerNotFoundException) {
+            // Prevent customer enumeration via timing attacks by always running password_verify().
+            password_verify($password, self::DUMMY_PASSWORD_HASH);
+
             throw CustomerException::badCredentials();
         }
 
         if ($customer->hasLegacyPassword()) {
             if (!$this->legacyPasswordVerifier->verify($password, $customer)) {
+                // Legacy md5/sha256 verification is far cheaper than bcrypt; match its cost so a wrong password does not reveal migrated accounts.
+                password_verify($password, self::DUMMY_PASSWORD_HASH);
+
                 throw CustomerException::badCredentials();
             }
 
@@ -137,8 +148,14 @@ class AccountService
             return $customer;
         }
 
-        if ($customer->getPassword() === null
-            || !password_verify($password, $customer->getPassword())) {
+        $passwordHash = $customer->getPassword();
+        if ($passwordHash === null) {
+            password_verify($password, self::DUMMY_PASSWORD_HASH);
+
+            throw CustomerException::badCredentials();
+        }
+
+        if (!password_verify($password, $passwordHash)) {
             throw CustomerException::badCredentials();
         }
 


### PR DESCRIPTION
> Mirror of an upstream pull request, opened for automated review. **Do not merge.**

|  |  |
|---|---|
| Upstream | https://github.com/shopware/shopware/pull/19008 |
| Author | `@umutdogan4291` |
| Base | `trunk` at merge-base `78e9464947ae` |
| Head | `304cf9d77855` |

---

### Original description

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
`/store-api/account/login` leaks registered emails via timing: a wrong password on a registered account runs bcrypt `password_verify()` (slow), an unregistered email skips it (fast). This ~2.5× gap enables account enumeration.

### 2. What does this change do, exactly?
In `AccountService::getCustomerByLogin()` it runs `password_verify()` against a dummy hash (DUMMY_PASSWORD_HASH) on every failure path that skips real hashing: unknown email, null hash, and failed legacy (md5/sha256) verify the legacy branch matters because its hashing is far cheaper than bcrypt. Behaviour is unchanged. No test added (nothing functional to assert); verified with a Docker timing PoC that closed the gap from ~300 ms to ~1–39 ms.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
relates https://github.com/shopware/shopware/security/advisories/GHSA-vjm7-8qq2-rgq6

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them



<!-- shopware-pr-mirror: upstream=shopware/shopware pr=19008 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login security by applying consistent password verification timing when credentials are invalid or account details are incomplete.
  * Preserved standard password validation while handling legacy or missing password credentials more securely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->