### PR TITLE
[#19044] chore: Prepare cookies for PHPStan update 2026-08

### DIFF
--- a/src/Core/Content/Cookie/Service/CookieProvider.php
+++ b/src/Core/Content/Cookie/Service/CookieProvider.php
@@ -215,10 +215,9 @@ class CookieProvider
     {
         foreach ($legacyCookieGroups as $legacyCookieGroup) {
             $snippetName = $legacyCookieGroup['snippet_name'] ?? null;
-            if ($snippetName === null) {
+            if (!\is_string($snippetName)) {
                 throw CookieException::invalidLegacyCookieGroupProvided($legacyCookieGroup);
             }
-            $snippetName = (string) $snippetName;
 
             $cookieGroup = $cookieGroupCollection->get($snippetName);
             if ($cookieGroup === null) {
@@ -258,10 +257,10 @@ class CookieProvider
 
                 foreach ($legacyCookieGroup['entries'] as $entry) {
                     $cookie = $entry['cookie'] ?? null;
-                    if ($cookie === null) {
+                    if (!\is_string($cookie)) {
                         throw CookieException::invalidLegacyCookieEntryProvided($entry);
                     }
-                    $cookieEntry = new CookieEntry((string) $cookie);
+                    $cookieEntry = new CookieEntry($cookie);
 
                     if (\array_key_exists('snippet_name', $entry)) {
                         $name = (string) $entry['snippet_name'];

--- a/src/Storefront/Framework/Cookie/CookieProviderInterface.php
+++ b/src/Storefront/Framework/Cookie/CookieProviderInterface.php
@@ -6,8 +6,8 @@ use Shopware\Core\Content\Cookie\Event\CookieGroupCollectEvent;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @phpstan-type CookieEntryArray array{cookie: string, value?: string, expiration?: string, snippet_name?: string, snippet_description?: string, hidden?: bool}
- * @phpstan-type CookieGroupArray array{isRequired?: bool, snippet_name: string, snippet_description?: string, cookie?: string, value?: string, expiration?: string, entries?: list<CookieEntryArray>}
+ * @phpstan-type CookieEntryArray array{cookie?: string, value?: string, expiration?: string, snippet_name?: string, snippet_description?: string, hidden?: bool}
+ * @phpstan-type CookieGroupArray array{isRequired?: bool, snippet_name?: string, snippet_description?: string, cookie?: string, value?: string, expiration?: string, entries?: list<CookieEntryArray>}
  *
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0. Use {@see CookieGroupCollectEvent} instead to introduce cookies.
  */

--- a/tests/unit/Core/Content/Cookie/Service/CookieProviderTest.php
+++ b/tests/unit/Core/Content/Cookie/Service/CookieProviderTest.php
@@ -202,7 +202,6 @@ class CookieProviderTest extends TestCase
         $translator = static::createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnArgument(0);
         $legacyCookieProvider = new LegacyCookieProviderForTesting(['name' => 'test-session-name-']);
-        /** @phpstan-ignore argument.type (Left out required array key for testing purpose) */
         $legacyCookieProvider->setTestCookieGroups([$invalidGroup]);
 
         $this->expectExceptionObject(CookieException::invalidLegacyCookieGroupProvided($invalidGroup));
@@ -224,7 +223,6 @@ class CookieProviderTest extends TestCase
         $translator = static::createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnArgument(0);
         $legacyCookieProvider = new LegacyCookieProviderForTesting(['name' => 'test-session-name-']);
-        /** @phpstan-ignore argument.type (Left out required array key for testing purpose) */
         $legacyCookieProvider->setTestCookieGroups([
             [
                 'snippet_name' => 'test-group-1',


### PR DESCRIPTION
> Mirror of an upstream pull request, opened for automated review. **Do not merge.**

|  |  |
|---|---|
| Upstream | https://github.com/shopware/shopware/pull/19044 |
| Author | `@mitelg` |
| Base | `trunk` at merge-base `ba1c3c711cc8` |
| Head | `7616e511cc01` |

---

### Original description

### 1. Why is this change necessary?

Preparation for https://github.com/shopware/shopware/pull/17661

### 2. What does this change do, exactly?

Prepare cookie code for PHPStan update

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them



<!-- shopware-pr-mirror: upstream=shopware/shopware pr=19044 -->

