### PR TITLE
[#19644] feat(framework): guard covers targets against the coverage source

### DIFF
--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/CodeCoverageIgnoreEvaluationRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/CodeCoverageIgnoreEvaluationRule.php
@@ -232,7 +232,10 @@ class CodeCoverageIgnoreEvaluationRule implements Rule
             return false;
         }
 
-        return (bool) preg_match('/@codeCoverageIgnore(?![A-Za-z])/', $doc->getText());
+        // match only a real docblock TAG (first token of its line, allowing the `/**` of a
+        // single-line docblock): a prose mention like "classes annotated with
+        // `@codeCoverageIgnore` stay valid targets" must not count as the annotation
+        return (bool) preg_match('/^[ \t]*(?:\/\*\*)?[ \t]*\**[ \t]*@codeCoverageIgnore(?![A-Za-z])/m', $doc->getText());
     }
 
     /**

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/CoversTargetInCoverageSourceRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/CoversTargetInCoverageSourceRule.php
@@ -1,0 +1,221 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Tests;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * PHPUnit 12 validates every CoversClass/CoversTrait target against the coverage
+ * `<source>` of the running suite and reports targets outside of it as "not a valid
+ * target for code coverage". PHPUnit 11 silently accepts them, so without this rule
+ * such targets only surface once the PHPUnit 12 upgrade lands.
+ *
+ * The rule resolves each target to its source file and requires that file to be
+ * inside the `<source><include>` list of phpunit.xml.dist and outside its
+ * `<source><exclude>` list. Classes annotated with `@codeCoverageIgnore` stay valid
+ * targets, so the annotation is deliberately not considered here.
+ *
+ * Enforced for the core unit suite only: the migration suite runs with its own
+ * scoped coverage source, and downstream repositories load this rule set with their
+ * own phpunit configurations.
+ *
+ * @internal
+ *
+ * @implements Rule<InClassNode>
+ */
+#[Package('framework')]
+class CoversTargetInCoverageSourceRule implements Rule
+{
+    private const UNIT_NAMESPACE = 'Shopware\Tests\Unit\\';
+
+    /**
+     * @var list<array{string, string}>|null resolved include entries as [directory, suffix]
+     */
+    private ?array $includes = null;
+
+    /**
+     * @var list<array{string, string}> resolved directory excludes as [directory, suffix]
+     */
+    private array $excludedDirectories = [];
+
+    /**
+     * @var list<string>
+     */
+    private array $excludedFiles = [];
+
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly string $projectDir,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param InClassNode $node
+     *
+     * @return array<array-key, RuleError|string>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $node->getClassReflection();
+        if (!\str_starts_with($classReflection->getName(), self::UNIT_NAMESPACE)) {
+            return [];
+        }
+
+        if (!TestRuleHelper::isTestClass($classReflection)) {
+            return [];
+        }
+
+        if (!$this->loadCoverageSource()) {
+            return [];
+        }
+
+        $errors = [];
+        foreach ($this->getCoversTargets($node) as $target) {
+            $file = $this->reflectionProvider->getClass($target)->getFileName();
+            if ($file === null) {
+                continue;
+            }
+
+            $relativePath = $this->relativePath($file);
+
+            if ($relativePath === null || !$this->matchesAnyInclude($relativePath)) {
+                $errors[] = RuleErrorBuilder::message(\sprintf(
+                    '%s is not part of the coverage source in phpunit.xml.dist, so it is not a valid coverage target under PHPUnit 12. Cover a class from the coverage source instead.',
+                    $target,
+                ))->identifier('shopware.coversExcludedTarget')->build();
+
+                continue;
+            }
+
+            if ($this->matchesAnyExclude($relativePath)) {
+                $errors[] = RuleErrorBuilder::message(\sprintf(
+                    '%s is excluded from the coverage source in phpunit.xml.dist, so it is not a valid coverage target under PHPUnit 12. Cover a class from the coverage source instead, or resolve the exclude.',
+                    $target,
+                ))->identifier('shopware.coversExcludedTarget')->build();
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return list<string> resolved target class names
+     */
+    private function getCoversTargets(InClassNode $class): array
+    {
+        $targets = [];
+
+        foreach ($class->getOriginalNode()->attrGroups as $group) {
+            foreach ($group->attrs as $attribute) {
+                if (!\in_array($attribute->name->toString(), [CoversClass::class, CoversTrait::class], true)) {
+                    continue;
+                }
+
+                $target = $this->resolveTargetName($attribute->args[0]->value ?? null);
+                if ($target !== null && $this->reflectionProvider->hasClass($target)) {
+                    $targets[] = $target;
+                }
+            }
+        }
+
+        return $targets;
+    }
+
+    private function resolveTargetName(?Node $argument): ?string
+    {
+        if ($argument instanceof ClassConstFetch && $argument->class instanceof Node\Name) {
+            return $argument->class->toString();
+        }
+
+        if ($argument instanceof String_) {
+            return $argument->value;
+        }
+
+        return null;
+    }
+
+    private function loadCoverageSource(): bool
+    {
+        if ($this->includes !== null) {
+            return $this->includes !== [];
+        }
+
+        $this->includes = [];
+
+        $configFile = $this->projectDir . '/phpunit.xml.dist';
+        if (!\is_file($configFile)) {
+            return false;
+        }
+
+        $config = simplexml_load_file($configFile);
+        if ($config === false || !isset($config->source)) {
+            return false;
+        }
+
+        foreach ($config->source->include->directory ?? [] as $directory) {
+            $this->includes[] = [\trim((string) $directory, '/'), (string) ($directory['suffix'] ?? '.php')];
+        }
+
+        foreach ($config->source->exclude->directory ?? [] as $directory) {
+            $this->excludedDirectories[] = [\trim((string) $directory, '/'), (string) ($directory['suffix'] ?? '.php')];
+        }
+
+        foreach ($config->source->exclude->file ?? [] as $file) {
+            $this->excludedFiles[] = \trim((string) $file, '/');
+        }
+
+        return $this->includes !== [];
+    }
+
+    private function relativePath(string $file): ?string
+    {
+        $prefix = \rtrim($this->projectDir, '/') . '/';
+        if (!\str_starts_with($file, $prefix)) {
+            return null;
+        }
+
+        return \substr($file, \strlen($prefix));
+    }
+
+    private function matchesAnyInclude(string $relativePath): bool
+    {
+        foreach ($this->includes ?? [] as [$directory, $suffix]) {
+            if (\str_starts_with($relativePath, $directory . '/') && \str_ends_with($relativePath, $suffix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function matchesAnyExclude(string $relativePath): bool
+    {
+        if (\in_array($relativePath, $this->excludedFiles, true)) {
+            return true;
+        }
+
+        foreach ($this->excludedDirectories as [$directory, $suffix]) {
+            if (\str_starts_with($relativePath, $directory . '/') && \str_ends_with($relativePath, $suffix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/core-rules.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/core-rules.neon
@@ -46,6 +46,14 @@ services:
         tags:
             - phpstan.rules.rule
 
+    # gated to the core unit suite inside the rule; downstream repositories run their own phpunit configurations
+    -
+        class: Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Tests\CoversTargetInCoverageSourceRule
+        arguments:
+            projectDir: %currentWorkingDirectory%
+        tags:
+            - phpstan.rules.rule
+
     -
         class: Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\TaggedServiceContractRule
         arguments:

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/CodeCoverageIgnoreEvaluationRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/CodeCoverageIgnoreEvaluationRuleTest.php
@@ -48,6 +48,8 @@ class CodeCoverageIgnoreEvaluationRuleTest extends RuleTestCase
 
         yield 'no annotation but logic present passes' => [['IgnoreStartEndOnlyClass.php'], []];
 
+        yield 'prose mention of the annotation is not an annotation' => [['ProseMentionClass.php'], []];
+
         yield 'exception fork branching is not logic, class ignore passes' => [['ExceptionForkClass.php'], []];
 
         yield 'exception with loop aggregation still fails' => [

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/CoversTargetInCoverageSourceRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/CoversTargetInCoverageSourceRuleTest.php
@@ -1,0 +1,106 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Tests\CoversTargetInCoverageSourceRule;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ *
+ * @extends RuleTestCase<CoversTargetInCoverageSourceRule>
+ */
+#[Package('framework')]
+class CoversTargetInCoverageSourceRuleTest extends RuleTestCase
+{
+    private const FIXTURE_DIR = __DIR__ . '/data/CoversTargetInCoverageSourceRule/Tests';
+
+    private const DATA_NAMESPACE = 'Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule';
+
+    #[TestDox('accepts targets inside the coverage source')]
+    public function testAllowedTargets(): void
+    {
+        $this->analyse([self::FIXTURE_DIR . '/CoversAllowedTargetFixture.php'], []);
+    }
+
+    #[TestDox('rejects a target matched by a suffix-scoped directory exclude')]
+    public function testSuffixExcludedTarget(): void
+    {
+        $this->analyse([self::FIXTURE_DIR . '/CoversSuffixExcludedFixture.php'], [
+            [
+                self::DATA_NAMESPACE . '\project\src\Boilerplate\ExcludedEntity is excluded from the coverage source in phpunit.xml.dist, so it is not a valid coverage target under PHPUnit 12. Cover a class from the coverage source instead, or resolve the exclude.',
+                9,
+            ],
+        ]);
+    }
+
+    #[TestDox('rejects a target matched by a whole-directory exclude')]
+    public function testDirectoryExcludedTarget(): void
+    {
+        $this->analyse([self::FIXTURE_DIR . '/CoversDirectoryExcludedFixture.php'], [
+            [
+                self::DATA_NAMESPACE . '\project\src\Tooling\ToolingHelper is excluded from the coverage source in phpunit.xml.dist, so it is not a valid coverage target under PHPUnit 12. Cover a class from the coverage source instead, or resolve the exclude.',
+                9,
+            ],
+        ]);
+    }
+
+    #[TestDox('rejects an excluded CoversTrait target')]
+    public function testExcludedTraitTarget(): void
+    {
+        $this->analyse([self::FIXTURE_DIR . '/CoversExcludedTraitFixture.php'], [
+            [
+                self::DATA_NAMESPACE . '\project\src\Tooling\ToolingTrait is excluded from the coverage source in phpunit.xml.dist, so it is not a valid coverage target under PHPUnit 12. Cover a class from the coverage source instead, or resolve the exclude.',
+                9,
+            ],
+        ]);
+    }
+
+    #[TestDox('rejects a target matched by a file exclude')]
+    public function testFileExcludedTarget(): void
+    {
+        $this->analyse([self::FIXTURE_DIR . '/CoversFileExcludedFixture.php'], [
+            [
+                self::DATA_NAMESPACE . '\project\src\SingleExcluded is excluded from the coverage source in phpunit.xml.dist, so it is not a valid coverage target under PHPUnit 12. Cover a class from the coverage source instead, or resolve the exclude.',
+                9,
+            ],
+        ]);
+    }
+
+    #[TestDox('rejects a target outside of the coverage source include list')]
+    public function testOutsideSourceTarget(): void
+    {
+        $this->analyse([self::FIXTURE_DIR . '/CoversOutsideSourceFixture.php'], [
+            [
+                self::DATA_NAMESPACE . '\Covered\OutsideSourceClass is not part of the coverage source in phpunit.xml.dist, so it is not a valid coverage target under PHPUnit 12. Cover a class from the coverage source instead.',
+                9,
+            ],
+        ]);
+    }
+
+    #[TestDox('skips tests without a class or trait target')]
+    public function testCoversNothing(): void
+    {
+        $this->analyse([self::FIXTURE_DIR . '/CoversNothingFixture.php'], []);
+    }
+
+    #[TestDox('skips tests outside of the core unit suite')]
+    public function testNonUnitNamespace(): void
+    {
+        $this->analyse([self::FIXTURE_DIR . '/NonUnitNamespaceFixture.php'], []);
+    }
+
+    /**
+     * @return CoversTargetInCoverageSourceRule
+     */
+    protected function getRule(): Rule
+    {
+        return new CoversTargetInCoverageSourceRule(
+            $this->createReflectionProvider(),
+            __DIR__ . '/data/CoversTargetInCoverageSourceRule/project',
+        );
+    }
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CodeCoverageIgnoreEvaluation/ProseMentionClass.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CodeCoverageIgnoreEvaluation/ProseMentionClass.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CodeCoverageIgnoreEvaluation;
+
+/**
+ * Explains that classes annotated with `@codeCoverageIgnore` stay valid coverage targets:
+ * a docblock that merely MENTIONS the annotation in prose does not carry it.
+ */
+class ProseMentionClass
+{
+    public function describe(string $value): string
+    {
+        if ($value === '') {
+            return 'empty';
+        }
+
+        return $value;
+    }
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/Covered/OutsideSourceClass.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/Covered/OutsideSourceClass.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\Covered;
+
+/**
+ * @internal
+ */
+class OutsideSourceClass
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/Tests/CoversAllowedTargetFixture.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/Tests/CoversAllowedTargetFixture.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\project\src\AllowedService;
+use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\project\src\Boilerplate\BoilerplateService;
+
+#[CoversClass(AllowedService::class)]
+#[CoversClass(BoilerplateService::class)]
+class CoversAllowedTargetFixture extends TestCase
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/Tests/CoversDirectoryExcludedFixture.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/Tests/CoversDirectoryExcludedFixture.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\project\src\Tooling\ToolingHelper;
+
+#[CoversClass(ToolingHelper::class)]
+class CoversDirectoryExcludedFixture extends TestCase
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/Tests/CoversExcludedTraitFixture.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/Tests/CoversExcludedTraitFixture.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\Tests;
+
+use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\TestCase;
+use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\project\src\Tooling\ToolingTrait;
+
+#[CoversTrait(ToolingTrait::class)]
+class CoversExcludedTraitFixture extends TestCase
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/Tests/CoversFileExcludedFixture.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/Tests/CoversFileExcludedFixture.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\project\src\SingleExcluded;
+
+#[CoversClass(SingleExcluded::class)]
+class CoversFileExcludedFixture extends TestCase
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/Tests/CoversNothingFixture.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/Tests/CoversNothingFixture.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\Tests;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+class CoversNothingFixture extends TestCase
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/Tests/CoversOutsideSourceFixture.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/Tests/CoversOutsideSourceFixture.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\Covered\OutsideSourceClass;
+
+#[CoversClass(OutsideSourceClass::class)]
+class CoversOutsideSourceFixture extends TestCase
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/Tests/CoversSuffixExcludedFixture.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/Tests/CoversSuffixExcludedFixture.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\project\src\Boilerplate\ExcludedEntity;
+
+#[CoversClass(ExcludedEntity::class)]
+class CoversSuffixExcludedFixture extends TestCase
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/Tests/NonUnitNamespaceFixture.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/Tests/NonUnitNamespaceFixture.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\project\src\Boilerplate\ExcludedEntity;
+
+#[CoversClass(ExcludedEntity::class)]
+class NonUnitNamespaceFixture extends TestCase
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/project/phpunit.xml.dist
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/project/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <exclude>
+            <directory suffix="Entity.php">src/Boilerplate</directory>
+            <directory suffix=".php">src/Tooling</directory>
+            <file>src/SingleExcluded.php</file>
+        </exclude>
+    </source>
+</phpunit>

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/project/src/AllowedService.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/project/src/AllowedService.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\project\src;
+
+/**
+ * @internal
+ */
+class AllowedService
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/project/src/Boilerplate/BoilerplateService.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/project/src/Boilerplate/BoilerplateService.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\project\src\Boilerplate;
+
+/**
+ * @internal
+ */
+class BoilerplateService
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/project/src/Boilerplate/ExcludedEntity.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/project/src/Boilerplate/ExcludedEntity.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\project\src\Boilerplate;
+
+/**
+ * @internal
+ */
+class ExcludedEntity
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/project/src/SingleExcluded.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/project/src/SingleExcluded.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\project\src;
+
+/**
+ * @internal
+ */
+class SingleExcluded
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/project/src/Tooling/ToolingHelper.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/project/src/Tooling/ToolingHelper.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\project\src\Tooling;
+
+/**
+ * @internal
+ */
+class ToolingHelper
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/project/src/Tooling/ToolingTrait.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversTargetInCoverageSourceRule/project/src/Tooling/ToolingTrait.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversTargetInCoverageSourceRule\project\src\Tooling;
+
+/**
+ * @internal
+ */
+trait ToolingTrait
+{
+}


### PR DESCRIPTION
> Mirror of an upstream pull request, opened for automated review. **Do not merge.**

|  |  |
|---|---|
| Upstream | https://github.com/shopware/shopware/pull/19644 |
| Author | `@nfortier-shopware` |
| Base | `test/coverage-covers-target-fixes` at merge-base `95b88d4f054c` |
| Head | `281b732125a0` |

---

### Original description

### 1. Why is this change necessary?

PHPUnit 12 validates every CoversClass/CoversTrait target against the coverage source of the running suite; PHPUnit 11 silently accepts targets outside of it. Without a static guard, invalid targets keep accumulating and only surface once the PHPUnit 12 upgrade lands.

### 2. What does this change do, exactly?

Adds `CoversTargetInCoverageSourceRule` to the core PHPStan rule set. The rule parses the `<source>` section of `phpunit.xml.dist` and reports every CoversClass/CoversTrait target in the core unit suite whose source file is outside the include list or matched by an exclude entry. Classes annotated with `@codeCoverageIgnore` remain valid targets and are deliberately not reported. The rule is gated to the `Shopware\Tests\Unit` namespace: downstream repositories load this rule set with their own phpunit configurations.

This PR must be merged last: it reports the tests whose covered classes only enter the coverage source through the open suffix-exclude lifts. It goes green once those are merged.

It also fixes a false positive this PR itself surfaced in `CodeCoverageIgnoreEvaluationRule`: the annotation detection matched `@codeCoverageIgnore` anywhere in a docblock, so this rule's own docblock (which documents the annotation's semantics in prose) was reported for every logic method. The detection is now anchored to a real docblock tag, with a prose-mention regression fixture.

### 3. Describe each step to reproduce the issue or behaviour.

Add a `#[CoversClass]` attribute pointing at a coverage-excluded class to a unit test: PHPStan passes today, and PHPUnit 12 reports the target as "not a valid target for code coverage".

### 4. Please link to the relevant issues (if any).

- relates `#18344`

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them




<!-- shopware-pr-mirror: upstream=shopware/shopware pr=19644 -->

