### PR TITLE
[#17314] feat: add check to dal:validate to ensure inheritance helper column for associations

### DIFF
--- a/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingDefinition.php
+++ b/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingDefinition.php
@@ -5,7 +5,6 @@ namespace Shopware\Core\Content\Product\SalesChannel\Sorting;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Inherited;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
@@ -58,7 +57,7 @@ class ProductSortingDefinition extends EntityDefinition
             (new BoolField('active', 'active'))->addFlags(new Required()),
             (new JsonField('fields', 'fields'))->addFlags(new Required()),
             (new TranslatedField('label'))->addFlags(new ApiAware()),
-            (new TranslationsAssociationField(ProductSortingTranslationDefinition::class, 'product_sorting_id'))->addFlags(new Inherited(), new Required()),
+            (new TranslationsAssociationField(ProductSortingTranslationDefinition::class, 'product_sorting_id'))->addFlags(new Required()),
         ]);
 
         return $collection;

--- a/src/Core/Framework/DataAbstractionLayer/DefinitionValidator.php
+++ b/src/Core/Framework/DataAbstractionLayer/DefinitionValidator.php
@@ -204,6 +204,8 @@ class DefinitionValidator
 
             $violations = array_merge_recursive($violations, $this->validateColumn($definition, $schema));
 
+            $violations = array_merge_recursive($violations, $this->validateInheritanceColumns($definition, $schema));
+
             $violations = array_merge_recursive($violations, $this->checkEntityNameConstant($definition));
 
             $struct = ArrayEntity::class;
@@ -981,6 +983,42 @@ class DefinitionValidator
         }
 
         return [$definition->getClass() => $notices];
+    }
+
+    /**
+     * @return array<class-string<EntityDefinition>, list<string>>
+     */
+    private function validateInheritanceColumns(EntityDefinition $definition, Schema $schema): array
+    {
+        if (!$schema->hasTable($definition->getEntityName())) {
+            return [];
+        }
+
+        $table = $schema->getTable($definition->getEntityName());
+        $violations = [];
+
+        foreach ($definition->getFields() as $field) {
+            if (!$field instanceof AssociationField || !$field->is(Inherited::class)) {
+                continue;
+            }
+
+            $columnName = $field->getPropertyName();
+            if ($table->hasColumn($columnName)) {
+                continue;
+            }
+
+            $violations[] = \sprintf(
+                'Field %s on %s is flagged as Inherited but the inheritance helper column `%s` is missing on table `%s`. Add a migration calling $this->updateInheritance($connection, \'%s\', \'%s\').',
+                $columnName,
+                $definition->getClass(),
+                $columnName,
+                $definition->getEntityName(),
+                $definition->getEntityName(),
+                $columnName
+            );
+        }
+
+        return [$definition->getClass() => $violations];
     }
 
     /**

--- a/tests/unit/Core/Framework/DataAbstractionLayer/DefinitionValidatorTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/DefinitionValidatorTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionValidator;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\Feature;
 use Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Validation\Fixtures\DefinitionStub;
+use Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Validation\Fixtures\DefinitionWithInheritedAssociationsStub;
 use Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Validation\Fixtures\DefinitionWithNonStorageAwarePrimaryKeyStub;
 
 /**
@@ -182,6 +183,107 @@ class DefinitionValidatorTest extends TestCase
         yield 'customer shipping address' => ['customer.defaultShippingAddress'];
         yield 'customer address billing customer' => ['customer_address.defaultBillingAddressCustomer'];
         yield 'customer address shipping customer' => ['customer_address.defaultShippingAddressCustomer'];
+    }
+
+    public function testInheritedAssociationHelperColumnPresentReportsNoViolation(): void
+    {
+        $definition = new DefinitionWithInheritedAssociationsStub();
+        $validator = $this->createValidatorWithColumns(
+            $definition,
+            ['id', 'foo', 'parent_id', 'optional_id', 'children', 'parent', 'optional', 'created_at', 'updated_at'],
+            ['id']
+        );
+
+        $violations = $validator->validate();
+        $inheritanceViolations = array_values(array_filter(
+            $violations[$definition::class] ?? [],
+            static fn (string $violation): bool => str_contains($violation, 'inheritance helper column')
+        ));
+
+        static::assertEmpty($inheritanceViolations, 'Expected no inheritance helper column violations, but got: ' . implode(', ', $inheritanceViolations));
+    }
+
+    public function testMissingInheritedHelperColumnReportsViolation(): void
+    {
+        $definition = new DefinitionWithInheritedAssociationsStub();
+        $validatorWithMissingColumns = $this->createValidatorWithColumns(
+            $definition,
+            ['id', 'foo', 'parent_id', 'optional_id', 'created_at', 'updated_at'],
+            ['id']
+        );
+
+        $violations = $validatorWithMissingColumns->validate();
+        $inheritanceViolations = array_values(array_filter(
+            $violations[$definition::class] ?? [],
+            static fn (string $violation): bool => str_contains($violation, 'inheritance helper column')
+        ));
+
+        static::assertCount(3, $inheritanceViolations, 'Expected three missing helper column violations, but got: ' . implode(', ', $inheritanceViolations));
+
+        $joined = implode("\n", $inheritanceViolations);
+        static::assertStringContainsString('helper column `children` is missing', $joined);
+        static::assertStringContainsString('helper column `parent` is missing', $joined);
+        static::assertStringContainsString('helper column `optional` is missing', $joined);
+    }
+
+    /**
+     * @param list<string> $columnNames
+     * @param list<string> $dbPrimaryKeys
+     */
+    private function createValidatorWithColumns(EntityDefinition $definition, array $columnNames, array $dbPrimaryKeys): DefinitionValidator
+    {
+        $pkConstraint = null;
+        if ($dbPrimaryKeys !== []) {
+            $pkColumns = array_map(
+                static function (string $col): UnqualifiedName {
+                    static::assertNotEmpty($col);
+
+                    return new UnqualifiedName(Identifier::unquoted($col));
+                },
+                $dbPrimaryKeys
+            );
+            $pkConstraint = new PrimaryKeyConstraint(null, $pkColumns, false);
+        }
+
+        $columns = array_map(
+            static fn (string $name): Column => new Column($name, Type::getType(Types::BINARY)),
+            $columnNames
+        );
+
+        $columnLookup = array_fill_keys($columnNames, true);
+
+        $table = $this->createMock(Table::class);
+        $table->method('getName')->willReturn($definition->getEntityName());
+        $table->method('getColumns')->willReturn($columns);
+        $table->method('getPrimaryKeyConstraint')->willReturn($pkConstraint);
+        $table->method('hasColumn')->willReturnCallback(
+            static fn (string $name): bool => isset($columnLookup[$name])
+        );
+
+        $schema = $this->createMock(Schema::class);
+        $schema->method('hasTable')->willReturn(true);
+        $schema->method('getTable')->willReturn($table);
+        $schema->method('getTables')->willReturn([$table]);
+
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $schemaManager->method('introspectSchema')->willReturn($schema);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('createSchemaManager')->willReturn($schemaManager);
+
+        $registry = $this->createMock(DefinitionInstanceRegistry::class);
+        $definition->compile($registry);
+        $registry->method('getDefinitions')->willReturn([$definition]);
+        $registry->method('getByEntityName')->willReturn($definition);
+        $registry->method('getByClassOrEntityName')->willReturn($definition);
+
+        // @phpstan-ignore class.extendsFinalByPhpDoc
+        return new class($registry, $connection) extends DefinitionValidator {
+            protected function shouldSkipDefinition(string $definitionClass): bool
+            {
+                return false;
+            }
+        };
     }
 
     /**

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Validation/Fixtures/DefinitionWithInheritedAssociationsStub.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Validation/Fixtures/DefinitionWithInheritedAssociationsStub.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Validation\Fixtures;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Inherited;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ *
+ * Test fixture with inherited associations
+ * Used to test validateInheritanceColumns() to ensure matching helper columns
+ */
+#[Package('framework')]
+class DefinitionWithInheritedAssociationsStub extends DefinitionStub
+{
+    protected function defineFields(): FieldCollection
+    {
+        $fields = parent::defineFields();
+
+        $fields->add(
+            (new FkField('parent_id', 'parentId', self::class))->addFlags(new Required())
+        );
+        $fields->add(
+            new FkField('optional_id', 'optionalId', self::class)
+        );
+        $fields->add(
+            (new OneToManyAssociationField('children', self::class, 'parent_id'))->addFlags(new Inherited())
+        );
+        $fields->add(
+            (new ManyToOneAssociationField('parent', 'parent_id', self::class, 'id'))->addFlags(new Inherited(), new Required())
+        );
+        $fields->add(
+            (new ManyToOneAssociationField('optional', 'optional_id', self::class, 'id'))->addFlags(new Inherited())
+        );
+
+        return $fields;
+    }
+}


### PR DESCRIPTION
> Mirror of an upstream pull request, opened for automated review. **Do not merge.**

|  |  |
|---|---|
| Upstream | https://github.com/shopware/shopware/pull/17314 |
| Author | `@M-arcus` |
| Base | `trunk` at merge-base `0b420c8e94f1` |
| Head | `74cac50a1d4d` |

---

### Original description

### 1. Why is this change necessary?

`bin/console dal:validate` does not report a missing inheritance helper field on a table. This field is created by `updateInheritance` in migrations and mentioned in the documentation: https://developer.shopware.com/docs/guides/plugins/plugins/framework/data-handling/field-inheritance.html#inheritance-columns. If not created it leads to issues during DBAL queries.

### 2. What does this change do, exactly?

It adds a check to `dal:validate` verify the columns existence. If not found it emits a warning.

I also removed an inherited flag from a translation, which gets ignored anyway.

### 3. Describe each step to reproduce the issue or behaviour.

Create an entity definition with an inherited association field that but do not add the helper field in the migration with `updateInheritance`. Some DBAL queries will now cause issues when using inherited assocation values. Before this change, this is never mentioned as a warning.

### 4. Please link to the relevant issues (if any).

https://developer.shopware.com/docs/guides/plugins/plugins/framework/data-handling/field-inheritance.html#inheritance-columns

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them



<!-- shopware-pr-mirror: upstream=shopware/shopware pr=17314 -->

