### PR TITLE
[#19991] ci: dispatch the commercial integration-major arm from nightly-major

### DIFF
--- a/.github/workflows/nightly-major.yml
+++ b/.github/workflows/nightly-major.yml
@@ -26,6 +26,34 @@ jobs:
     secrets: inherit
     if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
 
+  # Commercial arm: dispatch the plugin's integration-major workflow so the upcoming major's
+  # feature flags are also exercised with SwagCommercial installed (the regular downstream's
+  # major arm only runs whatever ref dispatched it; this one is pinned to the major schedule).
+  commercial-major:
+    name: Commercial (major)
+    if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    steps:
+      - id: sts
+        continue-on-error: true
+        uses: shopware/octo-sts-action@main
+        with:
+          scope: shopware
+          identity: ShopwareDownstream
+      - name: Commercial
+        uses: shopware/github-actions/downstream@main
+        if: steps.sts.outputs.token
+        env:
+          NEW_LOGIC: 1
+        with:
+          repo: shopware/SwagCommercial
+          workflow: integration-major.yaml
+          ref: .auto
+          timeout: 60m
+          poll_interval: 1m
+          token: ${{ steps.sts.outputs.token }}
+          upstream-token: ${{ github.token }}
+
   # turn a red major matrix into a domain-grouped tracking issue, aggregated from
   # the junit-phpunit-* artifacts integration-major.yml uploads on scheduled failures
   report-phpunit-failures:


### PR DESCRIPTION
> Mirror of an upstream pull request, opened for automated review. **Do not merge.**

|  |  |
|---|---|
| Upstream | https://github.com/shopware/shopware/pull/19991 |
| Author | `@nfortier-shopware` |
| Base | `trunk` at merge-base `45f050feafa1` |
| Head | `b82656436825` |

---

### Original description

### 1. Why is this change necessary?

The nightly major lane only covers core: acceptance (`major: only`) and `integration-major` run without SwagCommercial installed, so the upcoming major's feature flags are never exercised against the plugin on the major schedule. The plugin's own major Integration arm only runs as a side arm of whatever ref dispatches the regular Downstream.

### 2. What does this change do, exactly?

Adds a `commercial-major` job to `nightly-major.yml` that dispatches the plugin's `integration-major.yaml` workflow (the Integration suite with `FEATURE_ALL=major`) via the downstream action, with the same repository and dispatch guards as the other arms.

### 3. Describe each step to reproduce the issue or behaviour.

Trigger the Nightly Major workflow: no Commercial job exists.

### 4. Please link to the relevant issues (if any).

- relates `#17978`

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them



<!-- shopware-pr-mirror: upstream=shopware/shopware pr=19991 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added nightly major-schedule integration coverage for the commercial workflow.
  - Configured the downstream workflow to run with the new logic enabled, a 60-minute timeout, and 1-minute polling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->