### PR TITLE
[#19994] ci: report maintenance-branch nightly failures and crashed lanes

### DIFF
--- a/.github/bin/js/report-phpunit-nightly-failures.test.ts
+++ b/.github/bin/js/report-phpunit-nightly-failures.test.ts
@@ -9,6 +9,7 @@ import {
   groupByDomain,
   jestAppRoot,
   parseJestJUnitReport,
+  isNightlyBranch,
   parseJUnitReport,
   resolvePackageKey,
   scanReports,
@@ -338,5 +339,21 @@ describe('scanReports', () => {
     const scan = scanReports(reportDir);
 
     assert.deepEqual(scan.silentLanes, ['junit-phpunit-blue-green-66-67', 'junit-phpunit-died-before-reporting']);
+  });
+});
+
+describe('isNightlyBranch', () => {
+  it('accepts trunk and the maintenance branch shapes of release-gate.yml', () => {
+    assert.equal(isNightlyBranch('trunk'), true);
+    assert.equal(isNightlyBranch('6.6.x'), true);
+    assert.equal(isNightlyBranch('6.7.11.x'), true);
+  });
+
+  it('rejects every other branch, .x-suffixed backport branches included', () => {
+    assert.equal(isNightlyBranch('12753/allow-vtt-files-backport-6.6.x'), false);
+    assert.equal(isNightlyBranch('fix-backport-6.6.x'), false);
+    assert.equal(isNightlyBranch('6.7.0.0'), false);
+    assert.equal(isNightlyBranch('trunk-test'), false);
+    assert.equal(isNightlyBranch(''), false);
   });
 });

--- a/.github/bin/js/report-phpunit-nightly-failures.test.ts
+++ b/.github/bin/js/report-phpunit-nightly-failures.test.ts
@@ -11,6 +11,7 @@ import {
   parseJestJUnitReport,
   parseJUnitReport,
   resolvePackageKey,
+  scanReports,
 } from './report-phpunit-nightly-failures.ts';
 
 const JUNIT_FIXTURE = `<?xml version="1.0" encoding="UTF-8"?>
@@ -154,6 +155,36 @@ describe('groupByDomain / buildIssuePayload', () => {
     assert.equal(payload.issues[0].issueMarker, '<!-- nightly-phpunit-failures:domain/checkout -->');
   });
 
+  it('appends a silent-lane issue for red lanes whose reports carry no failing test', () => {
+    const group = {
+      label: 'domain/checkout',
+      packageKeys: new Set(['checkout']),
+      tests: [failedTest('Shopware\\Tests\\Integration\\Core\\Checkout\\CartTest', 'testFails')],
+    };
+    const payload = buildIssuePayload('[nightly] Nightly PHPUnit failures', [group], 'https://example.invalid/run/1', [
+      'junit-phpunit-blue-green-66-67',
+    ]);
+
+    assert.equal(payload.issues.length, 2);
+    const silent = payload.issues[1];
+    assert.equal(silent.issueTitle, '[nightly] Nightly PHPUnit failures: failed lane without test failures');
+    assert.equal(silent.issueMarker, '<!-- nightly-phpunit-failures:failed-lane-without-test-failures -->');
+    assert.equal(silent.label, null);
+    assert.ok(silent.issueBody.includes('`junit-phpunit-blue-green-66-67`'));
+    assert.ok(silent.issueBody.includes('runner-level error'));
+    assert.ok(silent.commentBody.startsWith(silent.issueMarker));
+  });
+
+  it('reports only the silent lanes when every parsed report is clean', () => {
+    const payload = buildIssuePayload('[nightly] Nightly PHPUnit failures', [], 'https://example.invalid/run/1', [
+      'junit-phpunit-blue-green-66-67',
+    ]);
+
+    assert.equal(payload.issues.length, 1);
+    assert.equal(payload.issues[0].issueTitle, '[nightly] Nightly PHPUnit failures: failed lane without test failures');
+    assert.ok(!payload.issues[0].issueBody.includes('No junit reports were produced'));
+  });
+
   it('falls back to a single no-reports issue when no failures were parsed', () => {
     const payload = buildIssuePayload('[nightly] Nightly PHPUnit failures', [], 'https://example.invalid/run/1');
 
@@ -248,5 +279,64 @@ describe('resolvePackageKey for jest component directories', () => {
 
     assert.equal(groups.length, 1);
     assert.equal(groups[0].label, 'needs manual routing');
+  });
+});
+
+describe('scanReports', () => {
+  let reportDir: string;
+
+  const CLEAN_JUNIT = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="blue-green" tests="2" failures="0" errors="0">
+    <testcase name="testPasses" class="Shopware\\Tests\\Integration\\Core\\Checkout\\CartTest"/>
+    <testcase name="testAlsoPasses" class="Shopware\\Tests\\Integration\\Core\\Checkout\\CartTest"/>
+  </testsuite>
+</testsuites>
+`;
+
+  const CLEAN_JEST = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Shopware 6 Unit Tests" tests="1" failures="0" errors="0">
+  <testsuite name="src/app/component/form/sw-field" errors="0" failures="0" tests="1">
+    <testcase classname="src/app/component/form/sw-field renders" name="src/app/component/form/sw-field renders" time="0.1">
+    </testcase>
+  </testsuite>
+</testsuites>
+`;
+
+  before(() => {
+    reportDir = mkdtempSync(join(tmpdir(), 'nightly-scan-'));
+
+    mkdirSync(join(reportDir, 'junit-phpunit-blue-green-66-67'));
+    writeFileSync(join(reportDir, 'junit-phpunit-blue-green-66-67/junit.xml'), CLEAN_JUNIT);
+
+    mkdirSync(join(reportDir, 'junit-phpunit-died-before-reporting'));
+
+    mkdirSync(join(reportDir, 'junit-phpunit-0'));
+    writeFileSync(join(reportDir, 'junit-phpunit-0/junit.xml'), JUNIT_FIXTURE);
+
+    // the same failures again: deduplicated globally, but the lane is not silent
+    mkdirSync(join(reportDir, 'junit-phpunit-1'));
+    writeFileSync(join(reportDir, 'junit-phpunit-1/junit.xml'), JUNIT_FIXTURE);
+
+    // clean jest artifacts are uploaded regardless of lane status and stay unflagged
+    mkdirSync(join(reportDir, 'jest-admin-results'));
+    writeFileSync(join(reportDir, 'jest-admin-results/admin.junit.xml'), CLEAN_JEST);
+  });
+
+  after(() => {
+    rmSync(reportDir, { recursive: true, force: true });
+  });
+
+  it('deduplicates failures across artifacts and counts every report', () => {
+    const scan = scanReports(reportDir);
+
+    assert.equal(scan.failures.length, 2);
+    assert.equal(scan.reports, 4);
+  });
+
+  it('flags only junit-phpunit lanes without a failing testcase, reportless ones included', () => {
+    const scan = scanReports(reportDir);
+
+    assert.deepEqual(scan.silentLanes, ['junit-phpunit-blue-green-66-67', 'junit-phpunit-died-before-reporting']);
   });
 });

--- a/.github/bin/js/report-phpunit-nightly-failures.ts
+++ b/.github/bin/js/report-phpunit-nightly-failures.ts
@@ -1,12 +1,17 @@
 #!/usr/bin/env node
 
-// Aggregates the junit.xml artifacts of a failed scheduled PHPUnit run into a
+// Aggregates the junit.xml artifacts of a failed nightly PHPUnit run into a
 // tracking-issue payload (consumed by .github/workflows/report-phpunit-failures.yml).
 // Failing tests are grouped by owning domain, resolved from the test file's
 // #[Package] attribute with a fallback to the dominant package of the mirrored
 // src/ directory. This is an inventory, not a triage: clustering failures into
 // root causes and filing per-domain issues stays a manual step — see
 // .agents/skills/nightly-triage/SKILL.md.
+//
+// A failed lane whose junit carries no failing test is reported as its own issue:
+// the junit-phpunit-* artifacts only exist for failed jobs, so a clean report
+// there means the failure is invisible to testcase-level aggregation (a
+// runner-level PHPUnit error, or a non-test step failing after a green suite).
 
 import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
@@ -300,6 +305,30 @@ function buildNoReportsIssue(issueTitle: string, runUrl: string): DomainIssue {
   };
 }
 
+// The junit-phpunit-* artifacts are only uploaded by failed jobs; one without a
+// failing testcase is a red lane the per-test aggregation cannot represent.
+function buildSilentLanesIssue(issueTitle: string, silentLanes: string[], runUrl: string): DomainIssue {
+  const marker = '<!-- nightly-phpunit-failures:failed-lane-without-test-failures -->';
+  const title = `${issueTitle}: failed lane without test failures`;
+  const lines = [
+    `Run: ${runUrl}`,
+    '',
+    'These lanes failed, but their junit reports contain no failing test:',
+    '',
+    ...silentLanes.map((lane) => `- \`${lane}\``),
+    '',
+    'Either PHPUnit hit a runner-level error it cannot attribute to a test (the console summary counts an error, for example a crash during a setUpBeforeClass kernel boot, while the junit report stays clean), or a step after a green suite failed. The failure is only visible in the job logs.',
+  ];
+
+  return {
+    issueTitle: title,
+    issueMarker: marker,
+    label: null,
+    issueBody: [marker, `# ${title}`, '', 'Latest failure:', '', ...lines].join('\n').trimEnd(),
+    commentBody: [marker, '## Scheduled test failure update', '', ...lines].join('\n').trimEnd(),
+  };
+}
+
 function buildDomainLines(group: DomainGroup, runUrl: string): string[] {
   const lines = [`Run: ${runUrl}`, `Failing tests: ${group.tests.length}`, ''];
 
@@ -313,11 +342,12 @@ function buildDomainLines(group: DomainGroup, runUrl: string): string[] {
   return lines;
 }
 
-export function buildIssuePayload(issueTitle: string, groups: DomainGroup[], runUrl: string): IssuePayload {
-  if (groups.length === 0) {
-    return { issues: [buildNoReportsIssue(issueTitle, runUrl)] };
-  }
-
+export function buildIssuePayload(
+  issueTitle: string,
+  groups: DomainGroup[],
+  runUrl: string,
+  silentLanes: string[] = []
+): IssuePayload {
   const issues = groups.map((group): DomainIssue => {
     const slug = group.label === UNROUTED_LABEL ? 'needs-manual-routing' : group.label;
     const marker = `<!-- nightly-phpunit-failures:${slug} -->`;
@@ -346,6 +376,14 @@ export function buildIssuePayload(issueTitle: string, groups: DomainGroup[], run
     };
   });
 
+  if (silentLanes.length > 0) {
+    issues.push(buildSilentLanesIssue(issueTitle, silentLanes, runUrl));
+  }
+
+  if (issues.length === 0) {
+    return { issues: [buildNoReportsIssue(issueTitle, runUrl)] };
+  }
+
   return { issues };
 }
 
@@ -361,6 +399,63 @@ function collectXmlFiles(directory: string): string[] {
 
     return entry.isFile() && entry.name.endsWith('.xml') ? [fullPath] : [];
   });
+}
+
+/**
+ * Walks the downloaded artifact directories. Every junit-phpunit-* artifact stems
+ * from a failed job (their upload steps run on `if: failure()`), so an artifact
+ * whose reports contain no failing testcase marks a red lane that testcase-level
+ * aggregation cannot see.
+ */
+export function scanReports(reportDirectory: string): { failures: FailedTest[]; silentLanes: string[]; reports: number } {
+  const seen = new Set<string>();
+  const failures: FailedTest[] = [];
+  const silentLanes: string[] = [];
+  let reports = 0;
+
+  const register = (xmlFile: string): number => {
+    const parsed = parseReport(xmlFile);
+    reports++;
+    for (const failure of parsed) {
+      const key = `${failure.className}::${failure.testName}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        failures.push(failure);
+      }
+    }
+
+    return parsed.length;
+  };
+
+  for (const entry of readdirSync(reportDirectory, { withFileTypes: true })) {
+    const fullPath = join(reportDirectory, entry.name);
+
+    if (entry.isFile()) {
+      if (entry.name.endsWith('.xml')) {
+        register(fullPath);
+      }
+      continue;
+    }
+
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    let laneFailures = 0;
+    for (const xmlFile of collectXmlFiles(fullPath)) {
+      laneFailures += register(xmlFile);
+    }
+
+    // an artifact directory without any junit.xml (a lane that died before
+    // reporting) is silent too: collectXmlFiles finds nothing, laneFailures stays 0
+    if (entry.name.startsWith('junit-phpunit-') && laneFailures === 0) {
+      silentLanes.push(entry.name);
+    }
+  }
+
+  silentLanes.sort();
+
+  return { failures, silentLanes, reports };
 }
 
 function main(): void {
@@ -382,24 +477,17 @@ function main(): void {
       : 'GitHub Actions run URL unavailable';
 
   const stats = statSync(reportDirectory, { throwIfNoEntry: false });
-  const xmlFiles = stats?.isDirectory() ? collectXmlFiles(resolve(reportDirectory)) : [];
+  const scan = stats?.isDirectory()
+    ? scanReports(resolve(reportDirectory))
+    : { failures: [], silentLanes: [], reports: 0 };
 
-  const seen = new Set<string>();
-  const failures: FailedTest[] = [];
-  for (const xmlFile of xmlFiles) {
-    for (const failure of parseReport(xmlFile)) {
-      const key = `${failure.className}::${failure.testName}`;
-      if (!seen.has(key)) {
-        seen.add(key);
-        failures.push(failure);
-      }
-    }
-  }
-
-  const payload = buildIssuePayload(issueTitle, groupByDomain(failures, repoRoot), runUrl);
+  const payload = buildIssuePayload(issueTitle, groupByDomain(scan.failures, repoRoot), runUrl, scan.silentLanes);
 
   writeFileSync(payloadFile, `${JSON.stringify(payload)}\n`, 'utf8');
-  console.log(`${failures.length} failing tests aggregated from ${xmlFiles.length} junit reports.`);
+  console.log(
+    `${scan.failures.length} failing tests aggregated from ${scan.reports} junit reports; ` +
+      `${scan.silentLanes.length} failed lanes without test failures.`
+  );
 }
 
 /** Jest artifacts land in jest-* subdirectories (see report-phpunit-failures.yml). */

--- a/.github/bin/js/report-phpunit-nightly-failures.ts
+++ b/.github/bin/js/report-phpunit-nightly-failures.ts
@@ -401,6 +401,13 @@ function collectXmlFiles(directory: string): string[] {
   });
 }
 
+// The tracking issues only reflect trunk and the maintenance branches; a nightly
+// dispatched manually on any other branch runs without reporting. The shapes mirror
+// the branch globs of release-gate.yml (6.6.x minor lines, 6.7.11.x patch lines).
+export function isNightlyBranch(refName: string): boolean {
+  return refName === 'trunk' || /^\d+\.\d+(\.\d+)?\.x$/.test(refName);
+}
+
 /**
  * Walks the downloaded artifact directories. Every junit-phpunit-* artifact stems
  * from a failed job (their upload steps run on `if: failure()`), so an artifact
@@ -468,6 +475,13 @@ function main(): void {
       'Usage: REPORT_TITLE="..." node report-phpunit-nightly-failures.ts <junit-report-directory> <payload-file>'
     );
     process.exit(1);
+  }
+
+  const refName = process.env['GITHUB_REF_NAME'] ?? '';
+  if (!isNightlyBranch(refName)) {
+    writeFileSync(payloadFile, `${JSON.stringify({ issues: [] })}\n`, 'utf8');
+    console.log(`Branch '${refName}' is neither trunk nor a maintenance branch: reporting skipped.`);
+    return;
   }
 
   const repoRoot = process.env['GITHUB_WORKSPACE'] ?? process.cwd();

--- a/.github/workflows/integration-major.yml
+++ b/.github/workflows/integration-major.yml
@@ -89,7 +89,7 @@ jobs:
           test-testsuite: ${{ matrix.test.testsuite }}
           # no codecov-upload step: the major run's signal is the gate, not Test Analytics
       - name: Upload junit report for the failure tracking issue
-        if: failure() && github.event_name == 'schedule'
+        if: failure() && github.event_name != 'pull_request' && github.event_name != 'merge_group'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: junit-phpunit-major-${{ strategy.job-index }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -113,7 +113,7 @@ jobs:
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload junit report for the failure tracking issue
-        if: failure() && github.event_name == 'schedule'
+        if: failure() && github.event_name != 'pull_request' && github.event_name != 'merge_group'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: junit-phpunit-${{ strategy.job-index }}
@@ -244,7 +244,7 @@ jobs:
         run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml --testsuite "integration" --stop-on-error --stop-on-failure
 
       - name: Upload junit report for the failure tracking issue
-        if: failure() && github.event_name == 'schedule'
+        if: failure() && github.event_name != 'pull_request' && github.event_name != 'merge_group'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: junit-phpunit-blue-green-67-68
@@ -343,7 +343,7 @@ jobs:
         run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml --testsuite "integration" --stop-on-error --stop-on-failure
 
       - name: Upload junit report for the failure tracking issue
-        if: failure() && github.event_name == 'schedule'
+        if: failure() && github.event_name != 'pull_request' && github.event_name != 'merge_group'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: junit-phpunit-blue-green-66-67
@@ -428,7 +428,7 @@ jobs:
         run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml --testsuite "integration" --stop-on-error --stop-on-failure
 
       - name: Upload junit report for the failure tracking issue
-        if: failure() && github.event_name == 'schedule'
+        if: failure() && github.event_name != 'pull_request' && github.event_name != 'merge_group'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: junit-phpunit-update-66-67

--- a/.github/workflows/nightly-major.yml
+++ b/.github/workflows/nightly-major.yml
@@ -29,7 +29,7 @@ jobs:
   # turn a red major matrix into a domain-grouped tracking issue, aggregated from
   # the junit-phpunit-* artifacts integration-major.yml uploads on scheduled failures
   report-phpunit-failures:
-    if: always() && github.event_name == 'schedule' && needs.integration-major.result == 'failure'
+    if: always() && needs.integration-major.result == 'failure'
     needs:
       - integration-major
     uses: ./.github/workflows/report-phpunit-failures.yml

--- a/.github/workflows/nightly-major.yml
+++ b/.github/workflows/nightly-major.yml
@@ -29,8 +29,8 @@ jobs:
   # turn a red major matrix into a domain-grouped tracking issue, aggregated from
   # the junit-phpunit-* artifacts integration-major.yml uploads on scheduled failures
   report-phpunit-failures:
-    # the branch guard keeps manual test dispatches on feature branches out of the tracking issues
-    if: always() && (github.ref_name == 'trunk' || endsWith(github.ref_name, '.x')) && needs.integration-major.result == 'failure'
+    # the aggregation script skips branches that are neither trunk nor maintenance-shaped
+    if: always() && needs.integration-major.result == 'failure'
     needs:
       - integration-major
     uses: ./.github/workflows/report-phpunit-failures.yml

--- a/.github/workflows/nightly-major.yml
+++ b/.github/workflows/nightly-major.yml
@@ -29,7 +29,8 @@ jobs:
   # turn a red major matrix into a domain-grouped tracking issue, aggregated from
   # the junit-phpunit-* artifacts integration-major.yml uploads on scheduled failures
   report-phpunit-failures:
-    if: always() && needs.integration-major.result == 'failure'
+    # the branch guard keeps manual test dispatches on feature branches out of the tracking issues
+    if: always() && (github.ref_name == 'trunk' || endsWith(github.ref_name, '.x')) && needs.integration-major.result == 'failure'
     needs:
       - integration-major
     uses: ./.github/workflows/report-phpunit-failures.yml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,9 +100,9 @@ jobs:
   # aggregated from the junit-phpunit-* artifacts those jobs upload on scheduled failures
   report-phpunit-failures:
     # maintenance-branch nightlies arrive as bot workflow_dispatch (schedule only fires on the default
-    # branch), so do not gate on the event; the branch guard keeps manual test dispatches on feature
-    # branches out of the tracking issues
-    if: always() && (github.ref_name == 'trunk' || endsWith(github.ref_name, '.x')) && (needs.redis.result == 'failure' || needs.integration.result == 'failure' || needs.php.result == 'failure')
+    # branch), so do not gate on the event; the aggregation script skips branches that are neither
+    # trunk nor maintenance-shaped, keeping manual test dispatches out of the tracking issues
+    if: always() && github.ref_type != 'tag' && (needs.redis.result == 'failure' || needs.integration.result == 'failure' || needs.php.result == 'failure')
     needs:
       - redis
       - integration

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -99,8 +99,10 @@ jobs:
   # turn red PHPUnit arms (redis, integration.yml, php.yml) into one domain-grouped tracking issue,
   # aggregated from the junit-phpunit-* artifacts those jobs upload on scheduled failures
   report-phpunit-failures:
-    # maintenance-branch nightlies arrive as bot workflow_dispatch (schedule only fires on the default branch), so do not gate on the event
-    if: always() && github.ref_type != 'tag' && (needs.redis.result == 'failure' || needs.integration.result == 'failure' || needs.php.result == 'failure')
+    # maintenance-branch nightlies arrive as bot workflow_dispatch (schedule only fires on the default
+    # branch), so do not gate on the event; the branch guard keeps manual test dispatches on feature
+    # branches out of the tracking issues
+    if: always() && (github.ref_name == 'trunk' || endsWith(github.ref_name, '.x')) && (needs.redis.result == 'failure' || needs.integration.result == 'failure' || needs.php.result == 'failure')
     needs:
       - redis
       - integration

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           ./vendor/bin/phpunit --log-junit junit.xml --testsuite redis
       - name: Upload junit report for the failure tracking issue
-        if: failure() && github.event_name == 'schedule'
+        if: failure() && github.event_name != 'pull_request' && github.event_name != 'merge_group'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: junit-phpunit-redis-${{ strategy.job-index }}
@@ -99,7 +99,8 @@ jobs:
   # turn red PHPUnit arms (redis, integration.yml, php.yml) into one domain-grouped tracking issue,
   # aggregated from the junit-phpunit-* artifacts those jobs upload on scheduled failures
   report-phpunit-failures:
-    if: always() && github.event_name == 'schedule' && (needs.redis.result == 'failure' || needs.integration.result == 'failure' || needs.php.result == 'failure')
+    # maintenance-branch nightlies arrive as bot workflow_dispatch (schedule only fires on the default branch), so do not gate on the event
+    if: always() && github.ref_type != 'tag' && (needs.redis.result == 'failure' || needs.integration.result == 'failure' || needs.php.result == 'failure')
     needs:
       - redis
       - integration

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -374,7 +374,7 @@ jobs:
           coverage-flags: phpunit-${{ matrix.suite }}
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload junit report for the failure tracking issue
-        if: failure() && github.event_name == 'schedule'
+        if: failure() && github.event_name != 'pull_request' && github.event_name != 'merge_group'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: junit-phpunit-${{ matrix.suite }}

--- a/.github/workflows/report-phpunit-failures.yml
+++ b/.github/workflows/report-phpunit-failures.yml
@@ -169,7 +169,6 @@ jobs:
               return created.data;
             };
 
-
             for (const issue of payload.issues) {
               const upserted = await upsert(issue, issue.label ? [issue.label] : []);
               try {

--- a/.github/workflows/report-phpunit-failures.yml
+++ b/.github/workflows/report-phpunit-failures.yml
@@ -52,8 +52,8 @@ jobs:
 
       # Issues created with the workflow token trigger no other workflows, and the project
       # auto-add leaves the Status field empty, so reporter-created issues never enter the
-      # domain triage boards. The script therefore sets "Pending Refinement" itself, with a
-      # token from the ManageProjects identity; without that token it logs and skips.
+      # domain triage boards. The script therefore sets the board's intake status itself,
+      # with a token from the ManageProjects identity; without that token it logs and skips.
       - id: sts
         continue-on-error: true
         uses: shopware/octo-sts-action@main
@@ -74,19 +74,28 @@ jobs:
 
             const projects = process.env.STS_TOKEN ? getOctokit(process.env.STS_TOKEN) : null;
 
-            const setPendingRefinement = async (item, issueNumber) => {
+            // The intake column is named differently per board (Pending Refinement, For
+            // Refinement, To be refined, Pending Triage, Backlog, ...); prefer a refine-named
+            // option, then a triage-named one, and fall back to the leftmost option, which is
+            // the intake lane on every board by convention.
+            const intakeOption = (options) =>
+              options.find((candidate) => /refine/i.test(candidate.name))
+                ?? options.find((candidate) => /triage/i.test(candidate.name))
+                ?? options[0];
+
+            const setIntakeStatus = async (item, issueNumber) => {
               const { node } = await projects.graphql(`query($id: ID!) {
                 node(id: $id) { ... on ProjectV2 { field(name: "Status") { ... on ProjectV2SingleSelectField { id options { id name } } } } }
               }`, { id: item.project.id });
-              const option = node?.field?.options?.find((candidate) => candidate.name === 'Pending Refinement');
+              const option = intakeOption(node?.field?.options ?? []);
               if (!option) {
-                core.info(`Project "${item.project.title}" has no "Pending Refinement" status; issue #${issueNumber} left as is`);
+                core.info(`Project "${item.project.title}" has no status options; issue #${issueNumber} left as is`);
                 return;
               }
               await projects.graphql(`mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
                 updateProjectV2ItemFieldValue(input: {projectId: $project, itemId: $item, fieldId: $field, value: {singleSelectOptionId: $option}}) { projectV2Item { id } }
               }`, { project: item.project.id, item: item.id, field: node.field.id, option: option.id });
-              core.info(`Set "Pending Refinement" on project "${item.project.title}" for issue #${issueNumber}`);
+              core.info(`Set "${option.name}" on project "${item.project.title}" for issue #${issueNumber}`);
             };
 
             // Put the issue into the triage lane of every domain project the auto-add bot
@@ -114,7 +123,7 @@ jobs:
                 const items = node?.projectItems?.nodes ?? [];
                 if (items.length > 0) {
                   for (const item of items.filter((candidate) => !candidate.fieldValueByName)) {
-                    await setPendingRefinement(item, issue.number);
+                    await setIntakeStatus(item, issue.number);
                   }
                   return;
                 }

--- a/.github/workflows/report-phpunit-failures.yml
+++ b/.github/workflows/report-phpunit-failures.yml
@@ -1,7 +1,7 @@
 name: Report PHPUnit failures
 
 # Files (or updates) one flat tracking issue per owning domain from the junit.xml
-# artifacts of a failed scheduled test run — deliberately no parent issue, flat
+# artifacts of a failed nightly run (scheduled on trunk, bot-dispatched on maintenance branches) — deliberately no parent issue, flat
 # per-domain issues only. Called by nightly.yml and nightly-major.yml;
 # the PHPUnit jobs of the run (redis, integration.yml, integration-major.yml, php.yml)
 # upload the `junit-phpunit-*` artifacts this consumes, the Jest jobs upload

--- a/.github/workflows/report-phpunit-failures.yml
+++ b/.github/workflows/report-phpunit-failures.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write # octo-sts, for the project status writes
   issues: write
 
 jobs:
@@ -49,15 +50,78 @@ jobs:
             "$RUNNER_TEMP/junit-reports" \
             "$RUNNER_TEMP/phpunit-failure-issue-payload.json"
 
+      # Issues created with the workflow token trigger no other workflows, and the project
+      # auto-add leaves the Status field empty, so reporter-created issues never enter the
+      # domain triage boards. The script therefore sets "Pending Refinement" itself, with a
+      # token from the ManageProjects identity; without that token it logs and skips.
+      - id: sts
+        continue-on-error: true
+        uses: shopware/octo-sts-action@main
+        with:
+          scope: shopware
+          identity: ManageProjects
+
       - name: Create or update tracking issues
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           ISSUE_PAYLOAD_FILE: ${{ runner.temp }}/phpunit-failure-issue-payload.json
+          STS_TOKEN: ${{ steps.sts.outputs.token }}
         with:
           script: |
             const fs = require('node:fs');
             const payload = JSON.parse(fs.readFileSync(process.env.ISSUE_PAYLOAD_FILE, 'utf8'));
             const { owner, repo } = context.repo;
+
+            const projects = process.env.STS_TOKEN ? getOctokit(process.env.STS_TOKEN) : null;
+
+            const setPendingRefinement = async (item, issueNumber) => {
+              const { node } = await projects.graphql(`query($id: ID!) {
+                node(id: $id) { ... on ProjectV2 { field(name: "Status") { ... on ProjectV2SingleSelectField { id options { id name } } } } }
+              }`, { id: item.project.id });
+              const option = node?.field?.options?.find((candidate) => candidate.name === 'Pending Refinement');
+              if (!option) {
+                core.info(`Project "${item.project.title}" has no "Pending Refinement" status; issue #${issueNumber} left as is`);
+                return;
+              }
+              await projects.graphql(`mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+                updateProjectV2ItemFieldValue(input: {projectId: $project, itemId: $item, fieldId: $field, value: {singleSelectOptionId: $option}}) { projectV2Item { id } }
+              }`, { project: item.project.id, item: item.id, field: node.field.id, option: option.id });
+              core.info(`Set "Pending Refinement" on project "${item.project.title}" for issue #${issueNumber}`);
+            };
+
+            // Put the issue into the triage lane of every domain project the auto-add bot
+            // attached it to: an item without a Status is invisible on the domain boards.
+            const ensureTriageStatus = async (issue) => {
+              if (!projects) {
+                core.warning(`No project token available: triage status not set for issue #${issue.number}`);
+                return;
+              }
+              // the auto-add bot attaches project items asynchronously; poll briefly
+              for (let attempt = 0; attempt < 6; attempt++) {
+                const { node } = await projects.graphql(`query($id: ID!) {
+                  node(id: $id) {
+                    ... on Issue {
+                      projectItems(first: 10) {
+                        nodes {
+                          id
+                          project { id title }
+                          fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue { name } }
+                        }
+                      }
+                    }
+                  }
+                }`, { id: issue.node_id });
+                const items = node?.projectItems?.nodes ?? [];
+                if (items.length > 0) {
+                  for (const item of items.filter((candidate) => !candidate.fieldValueByName)) {
+                    await setPendingRefinement(item, issue.number);
+                  }
+                  return;
+                }
+                await new Promise((resolve) => setTimeout(resolve, 10000));
+              }
+              core.warning(`No project items appeared for issue #${issue.number}; triage status not set`);
+            };
 
             const openIssues = await github.paginate(github.rest.issues.listForRepo, {
               owner,
@@ -96,6 +160,13 @@ jobs:
               return created.data;
             };
 
+
             for (const issue of payload.issues) {
-              await upsert(issue, issue.label ? [issue.label] : []);
+              const upserted = await upsert(issue, issue.label ? [issue.label] : []);
+              try {
+                // also heals commented issues whose status is still empty
+                await ensureTriageStatus(upserted);
+              } catch (error) {
+                core.warning(`Could not set the triage status for issue #${upserted.number}: ${error.message}`);
+              }
             }


### PR DESCRIPTION
> Mirror of an upstream pull request, opened for automated review. **Do not merge.**

|  |  |
|---|---|
| Upstream | https://github.com/shopware/shopware/pull/19994 |
| Author | `@nfortier-shopware` |
| Base | `trunk` at merge-base `fef3ee45886b` |
| Head | `a2908c919037` |

---

### Original description

### 1. Why is this change necessary?

Nightly PHPUnit failures on maintenance branches never reach the tracking issues: GitHub only fires `schedule` on the default branch, so the 6.6.x/6.7.x nightlies run as bot-dispatched `workflow_dispatch` and every `github.event_name == 'schedule'` gate skips both the junit uploads and the report jobs. Independently, a lane that fails without a test-attributable failure (for example a runner-level `NoTestCaseObjectOnCallStackException` during a setUpBeforeClass kernel boot) produces a junit report with zero failing testcases, so the aggregation drops the lane silently.

The issues the reporter does create also skip the domain triage: issues created with the workflow token trigger no other workflows, and the project auto-add leaves the Status field empty, so they never surface on the domain boards until someone sets a status by hand.

### 2. What does this change do, exactly?

- Replaces the schedule-only conditions on the seven junit upload steps with an exclusion of PR contexts (`pull_request`, `merge_group`), and drops the schedule check from the two report jobs, so bot-dispatched maintenance-branch nightlies report like trunk's scheduled run.
- Teaches the aggregation script to flag red lanes without test failures: `junit-phpunit-*` artifacts only exist for failed jobs, so an artifact whose reports contain no failing testcase (or no report at all) is collected into a dedicated "failed lane without test failures" issue naming the lanes. Jest artifacts are not failure-gated and stay exempt.
- Stops the "no test reports" fallback from firing when reports exist but are all clean; it keeps covering the case where nothing was uploaded.
- Sets the board's intake status on the status-less project items of reported issues (a refine-named option, a triage-named one, or the leftmost as fallback, since the column names differ per board; token from the ManageProjects octo-sts identity, with a logged skip when it is unavailable), so they enter the domain triage lanes. Commented issues with a still-empty status are healed too.
- Restricts reporting to trunk and the maintenance branch shapes of release-gate.yml (`6.6.x` minor lines, `6.7.11.x` patch lines), checked by the aggregation script, so a manual test dispatch of a nightly on any other branch runs without touching the tracking issues.

### 3. Describe each step to reproduce the issue or behaviour.

Let a maintenance-branch nightly fail: no issue is filed or commented. Let a blue-green lane crash at static kernel boot on trunk's scheduled nightly: the console summary counts an error and the job exits 2, but the junit report holds zero failing testcases and the report omits the lane.

### 4. Please link to the relevant issues (if any).

none

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them



<!-- shopware-pr-mirror: upstream=shopware/shopware pr=19994 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PHPUnit failure reporting now detects failed lanes even when no individual test cases are listed.
  * Duplicate failures are consolidated, and lanes without reports retain the appropriate fallback handling.
  * Nightly reporting is restricted to trunk and supported maintenance branches.

* **Improvements**
  * Failed test reports are collected from more workflow runs, excluding pull requests and merge-group runs.
  * Tracking issues now include silent-lane details and are automatically assigned the appropriate project intake status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->