### PR TITLE
[#20007] fix: resolve root inline aliases for composer-managed plugin versions

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -2,6 +2,10 @@
 
 ## Core
 
+### Composer inline aliases resolve to the aliased plugin version
+
+When a composer-managed plugin is required with a root-level inline alias (e.g. `"swag/paypal": "dev-bugfix as 10.8.1"`), `plugin:refresh` now stores the aliased version (`10.8.1`) instead of the raw branch version (`dev-bugfix`). Previously the branch version was written to the plugin table, where `version_compare` treats it as older than any release, so the next plugin update re-ran every version-gated update step of the plugin — re-running destructive migrations and resetting plugin configuration. Plugin update logic that compares `$updateContext->getCurrentPluginVersion()` against release versions now works for installations that pin such aliased dev branches.
+
 ### State machine transitions resolve deterministically
 
 When a state machine contains multiple transitions with the same action name and source state but different destination states, firing that action now deterministically resolves to the oldest transition instead of an undefined one. Such conflicting transitions are deprecated: resolving or writing them triggers a deprecation notice, and with v6.8.0.0 existing duplicates are removed and new ones are prevented by a unique database constraint. If your extension needs its own destination state, register the transition under its own action name instead of reusing an existing one.

--- a/changelog/_unreleased/2026-09-02-resolve-root-inline-aliases-for-plugin-versions.md
+++ b/changelog/_unreleased/2026-09-02-resolve-root-inline-aliases-for-plugin-versions.md
@@ -1,0 +1,6 @@
+---
+title: Resolve root inline aliases for plugin versions
+issue: NEXT-00000
+---
+# Core
+* Changed `Shopware\Core\Framework\Plugin\Util\PluginFinder` to resolve root-level composer inline aliases (e.g. requiring a plugin as `dev-bugfix as 1.2.3`), so the plugin version is reported as the aliased version instead of the raw branch version. Previously the branch version (e.g. `dev-bugfix`) was written to the plugin table, where it compared as older than any release version and caused plugins to re-run all of their update migration steps on the next update.

--- a/changelog/_unreleased/2026-09-02-resolve-root-inline-aliases-for-plugin-versions.md
+++ b/changelog/_unreleased/2026-09-02-resolve-root-inline-aliases-for-plugin-versions.md
@@ -1,6 +1,0 @@
----
-title: Resolve root inline aliases for plugin versions
-issue: NEXT-00000
----
-# Core
-* Changed `Shopware\Core\Framework\Plugin\Util\PluginFinder` to resolve root-level composer inline aliases (e.g. requiring a plugin as `dev-bugfix as 1.2.3`), so the plugin version is reported as the aliased version instead of the raw branch version. Previously the branch version (e.g. `dev-bugfix`) was written to the plugin table, where it compared as older than any release version and caused plugins to re-run all of their update migration steps on the next update.

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -638,12 +638,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/src/Core/Framework/Plugin/Requirement/RequirementExceptionStack.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
-    'identifier' => 'empty.notAllowed',
-    'count' => 1,
-    'path' => __DIR__ . '/src/Core/Framework/Plugin/Util/PluginFinder.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Throwing new exceptions within classes are not allowed. Please use domain exception pattern. See https://github.com/shopware/platform/blob/v6.4.20.0/adr/2022-02-24-domain-exceptions.md',
     'identifier' => 'shopware.domainException',
     'count' => 2,

--- a/src/Core/Framework/Plugin/Util/PluginFinder.php
+++ b/src/Core/Framework/Plugin/Util/PluginFinder.php
@@ -4,6 +4,8 @@ namespace Shopware\Core\Framework\Plugin\Util;
 
 use Composer\Composer;
 use Composer\IO\IOInterface;
+use Composer\Package\CompleteAliasPackage;
+use Composer\Package\CompletePackage;
 use Composer\Package\CompletePackageInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Composer\Factory;
@@ -125,6 +127,8 @@ class PluginFinder
             ->getLocalRepository()
             ->getPackages();
 
+        $rootAliases = $composer->getPackage()->getAliases();
+
         foreach ($composerPackages as $composerPackage) {
             if (!$this->isShopwarePluginType($composerPackage)) {
                 continue;
@@ -148,7 +152,7 @@ class PluginFinder
                 'path' => $localPlugin?->getPath() ?? $pluginPath,
                 'managedByComposer' => true,
                 // use local composer package (if it exists) as composer caches the version info
-                'composerPackage' => $localPlugin?->getComposerPackage() ?? $composerPackage,
+                'composerPackage' => $localPlugin?->getComposerPackage() ?? $this->applyRootAlias($composerPackage, $rootAliases),
             ]);
         }
 
@@ -164,6 +168,30 @@ class PluginFinder
         }
 
         return $plugins;
+    }
+
+    /**
+     * Root-level inline aliases (e.g. requiring a plugin as "dev-bugfix as 1.2.3") are not applied to the
+     * packages of the installed repository, so without resolving them here the plugin version would be
+     * reported as the raw branch version ("dev-bugfix") and break version comparisons during plugin updates.
+     *
+     * @param list<array{package: string, version: string, alias: string, alias_normalized: string}> $rootAliases
+     */
+    private function applyRootAlias(CompletePackageInterface $package, array $rootAliases): CompletePackageInterface
+    {
+        $basePackage = $package instanceof CompleteAliasPackage ? $package->getAliasOf() : $package;
+
+        if (!$basePackage instanceof CompletePackage) {
+            return $package;
+        }
+
+        foreach ($rootAliases as $rootAlias) {
+            if ($rootAlias['package'] === $basePackage->getName() && $rootAlias['version'] === $basePackage->getVersion()) {
+                return new CompleteAliasPackage($basePackage, $rootAlias['alias_normalized'], $rootAlias['alias']);
+            }
+        }
+
+        return $package;
     }
 
     private function getVendorPluginPath(CompletePackageInterface $pluginPackage, Composer $composer): string

--- a/src/Core/Framework/Plugin/Util/PluginFinder.php
+++ b/src/Core/Framework/Plugin/Util/PluginFinder.php
@@ -97,9 +97,13 @@ class PluginFinder
 
     private function isPluginComposerValid(CompletePackageInterface $package): bool
     {
-        return isset($package->getExtra()[self::SHOPWARE_PLUGIN_CLASS_EXTRA_IDENTIFIER])
-            && $package->getExtra()[self::SHOPWARE_PLUGIN_CLASS_EXTRA_IDENTIFIER] !== ''
-            && !empty($package->getExtra()['label']);
+        $extra = $package->getExtra();
+        $label = $extra['label'] ?? null;
+
+        return isset($extra[self::SHOPWARE_PLUGIN_CLASS_EXTRA_IDENTIFIER])
+            && $extra[self::SHOPWARE_PLUGIN_CLASS_EXTRA_IDENTIFIER] !== ''
+            && \is_array($label)
+            && $label !== [];
     }
 
     private function getPluginNameFromPackage(CompletePackageInterface $pluginPackage): string

--- a/tests/unit/Core/Framework/Plugin/Util/PluginFinderTest.php
+++ b/tests/unit/Core/Framework/Plugin/Util/PluginFinderTest.php
@@ -40,7 +40,7 @@ class PluginFinderTest extends TestCase
             new ExceptionCollection(),
             new NullIO()
         );
-        static::assertCount(2, $plugins);
+        static::assertCount(3, $plugins);
         static::assertSame($plugins['Swag\Test']->getBaseClass(), 'Swag\Test');
     }
 
@@ -82,5 +82,24 @@ class PluginFinderTest extends TestCase
         static::assertSame(__DIR__ . '/_fixture/ComposerProject/vendor/swag/test2', $plugins['Swag\Test2']->getPath());
         // version info is still from local, as that might be more up to date
         static::assertSame('v2.0.1', $plugins['Swag\Test2']->getComposerPackage()->getPrettyVersion());
+    }
+
+    /*
+     * Swag\Test3 is required by the root composer.json as "dev-codex/some-fix as 3.0.0". The installed
+     * repository only contains the branch version, so the root inline alias has to be resolved to report
+     * the plugin version as "3.0.0" instead of the incomparable "dev-codex/some-fix".
+     */
+    public function testResolvesRootInlineAliasesForVendorPlugins(): void
+    {
+        $plugins = (new PluginFinder(new PackageProvider()))->findPlugins(
+            __DIR__ . '/_fixture/LocallyInstalledPlugins',
+            __DIR__ . '/_fixture/ComposerProject',
+            new ExceptionCollection(),
+            new NullIO()
+        );
+
+        static::assertInstanceOf(PluginFromFileSystemStruct::class, $plugins['Swag\Test3']);
+        static::assertSame('3.0.0', $plugins['Swag\Test3']->getComposerPackage()->getPrettyVersion());
+        static::assertSame('3.0.0.0', $plugins['Swag\Test3']->getComposerPackage()->getVersion());
     }
 }

--- a/tests/unit/Core/Framework/Plugin/Util/_fixture/ComposerProject/composer.json
+++ b/tests/unit/Core/Framework/Plugin/Util/_fixture/ComposerProject/composer.json
@@ -11,6 +11,7 @@
         }
     ],
     "require": {
-        "shopware/platform": "6.4.*@dev"
+        "shopware/platform": "6.4.*@dev",
+        "swag/test3": "dev-codex/some-fix as 3.0.0"
     }
 }

--- a/tests/unit/Core/Framework/Plugin/Util/_fixture/ComposerProject/vendor/composer/installed.json
+++ b/tests/unit/Core/Framework/Plugin/Util/_fixture/ComposerProject/vendor/composer/installed.json
@@ -47,6 +47,31 @@
           "de-DE": "Test plugin"
         }
       }
+    },
+    {
+      "name": "swag/test3",
+      "type": "shopware-platform-plugin",
+      "description": "Test description",
+      "version": "dev-codex/some-fix",
+      "version_normalized": "dev-codex/some-fix",
+      "license": "MIT",
+      "authors": [
+        {
+          "name": "shopware AG",
+          "role": "Manufacturer"
+        }
+      ],
+      "require": {
+        "shopware/platform": "6.4.*@dev"
+      },
+      "install-path": "../swag/test3",
+      "extra": {
+        "shopware-plugin-class": "Swag\\Test3",
+        "label": {
+          "en-GB": "Test plugin",
+          "de-DE": "Test plugin"
+        }
+      }
     }
   ]
 }

--- a/tests/unit/Core/Framework/Plugin/Util/_fixture/ComposerProject/vendor/swag/test3/composer.json
+++ b/tests/unit/Core/Framework/Plugin/Util/_fixture/ComposerProject/vendor/swag/test3/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "swag/test3",
+    "description": "Test 3 description",
+    "version": "dev-codex/some-fix",
+    "type": "shopware-platform-plugin",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "shopware AG",
+            "role": "Manufacturer"
+        }
+    ],
+    "require": {
+        "shopware/platform": "6.4.*@dev"
+    },
+    "extra": {
+        "shopware-plugin-class": "Swag\\Test3",
+        "label": {
+            "en-GB": "Test plugin",
+            "de-DE": "Test plugin"
+        }
+    }
+}


### PR DESCRIPTION
> Mirror of an upstream pull request, opened for automated review. **Do not merge.**

|  |  |
|---|---|
| Upstream | https://github.com/shopware/shopware/pull/20007 |
| Author | `@jenskueper` |
| Base | `trunk` at merge-base `45f050feafa1` |
| Head | `fe2456ee8cf0` |

---

### Original description

### 1. Why is this change necessary?

A plugin required with a root-level composer inline alias (e.g. `"swag/paypal": "dev-bugfix as 10.8.1"`) is reported with its raw branch version, because composer does not apply root aliases to the packages of the installed repository. The branch version (`dev-bugfix`) ends up in the `plugin` table, where `version_compare` treats it as older than any release version.

As a consequence, the next plugin update re-runs **all** of the plugin's version-gated update migration steps. For SwagPayPal on SaaS this reset merchant settings (e.g. `acdcForce3DS` back to `false`) and crashed on settings values that only exist in newer versions.

### 2. What does this change do, exactly?

`PluginFinder::enrichWithVendorPlugins()` now matches each vendor plugin package against the root package's inline aliases (`$composer->getPackage()->getAliases()`) and wraps matches in a `CompleteAliasPackage`. The existing `PluginService`/`VersionSanitizer` pipeline then reports the aliased version (`10.8.1`) instead of the branch version, so a real, comparable version is written to the `plugin` table.

Default-branch handling (`DEFAULT_BRANCH_ALIAS`) and locally installed plugins (`custom/plugins`) are unchanged.

### 3. Describe each step to reproduce the issue or behaviour.

1. In a Shopware project, require a plugin from a non-default branch with an inline alias, e.g. `composer require "swag/paypal:dev-some-branch as 10.8.1"`.
2. Run `bin/console plugin:refresh` and `bin/console plugin:list`.
3. The plugin version is shown/stored as `dev-some-branch` instead of `10.8.1`.
4. Update the plugin to a newer version: every `version_compare($updateContext->getCurrentPluginVersion(), 'x.y.z', '<')` in the plugin's update logic evaluates to `true` and all update steps run again.

### 4. Please link to the relevant issues (if any).

- No public issue; fixes the root cause of an internal SaaS incident where a `dev-codex/... as 10.8.1` requirement of SwagPayPal re-ran all plugin update migrations and reset merchant settings.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- shopware-pr-mirror: upstream=shopware/shopware pr=20007 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Plugin refresh now recognizes Composer inline aliases and records the aliased release version.
  - Prevents repeated version-gated update steps, including potentially destructive migrations and plugin configuration resets, for plugins installed from aliased development branches.
  - Improves plugin version comparisons for Composer-managed installations.

- **Tests**
  - Added coverage for resolving and reporting aliased plugin versions correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->