### PR TITLE
[#20045] ci: gate the unit, migration and devops suites on phpunit 12

### DIFF
--- a/.github/actions/phpunit-prepare/action.yaml
+++ b/.github/actions/phpunit-prepare/action.yaml
@@ -18,6 +18,9 @@ inputs:
   migration-coverage:
     default: "false"
     description: "Rewrite phpunit.xml.dist to scope coverage to the */Migration directories (migration suite)"
+  force-phpunit-12:
+    default: "false"
+    description: "Force PHPUnit 12 via `composer update phpunit/phpunit:^12.4` after the test install (12.4 ships --fail-on-phpunit-notice/-warning). Used by the phpunit-12 gate job."
 
 # Note: the caller controls feature flags via job-level env (e.g. FEATURE_ALL: major); the steps below
 # inherit it, so this action stays flag-agnostic. The caller must run actions/checkout before using this
@@ -25,6 +28,23 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Export the canonical PHPUnit environment
+      # every PHPUnit job runs against the same test app and service endpoints; exporting them here
+      # keeps the values out of each job's env block (FEATURE_ALL stays with the caller: it is
+      # matrix- and workflow-specific). APP_SECRET is a fixed test value, not a real secret.
+      shell: bash
+      run: |
+        {
+          echo "APP_ENV=test"
+          echo "DATABASE_URL=mysql://root@127.0.0.1:3306/root"
+          echo "APP_URL=http://localhost:8000"
+          echo "APP_SECRET=def00000bb5acb32b54ff8ee130270586eec0e878f7337dc7a837acc31d3ff00f93a56b595448b4b29664847dd51991b3314ff65aeeeb761a133b0ec0e070433bff08e48"
+          echo "OPENSEARCH_URL=127.0.0.1:9200"
+          echo "ADMIN_OPENSEARCH_URL=127.0.0.1:9200"
+          echo "BLUE_GREEN_DEPLOYMENT=1"
+          echo "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true"
+        } >> "$GITHUB_ENV"
+
     - name: Setup Shopware
       uses: shopware/setup-shopware@main
       with:
@@ -65,3 +85,10 @@ runs:
     - name: Install Shopware
       shell: bash
       run: php src/Core/TestBootstrap.php
+
+    - name: Force PHPUnit 12
+      if: ${{ inputs.force-phpunit-12 == 'true' }}
+      shell: bash
+      # composer require rewrites the root constraint for this run only, so every other job
+      # keeps resolving PHPUnit 11 (a shared ||-constraint made composer pick 12 everywhere)
+      run: composer require --dev --update-with-all-dependencies phpunit/phpunit:^12.4

--- a/.github/actions/phpunit-run/action.yaml
+++ b/.github/actions/phpunit-run/action.yaml
@@ -12,6 +12,9 @@ inputs:
   coverage:
     default: "false"
     description: "Run with cobertura coverage (written to coverage.xml for ./.github/actions/phpunit-upload)"
+  phpunit-options:
+    default: ""
+    description: "Extra CLI options appended to the PHPUnit call (preview: `--display-phpunit-notices` on the PHPUnit 12 arm; PHPUnit 11 does not know the flag)"
 
 # Note: the caller controls feature flags via job-level env (e.g. FEATURE_ALL: major); the run steps below
 # inherit it, so this action stays flag-agnostic. Environment setup (PHP, database, webserver, test install)
@@ -23,9 +26,9 @@ runs:
     - name: Run PHPUnit testsuite
       if: ${{ inputs.test-testsuite != '' }}
       shell: bash
-      run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml ${{ inputs.coverage == 'true' && '--coverage-cobertura coverage.xml' || '' }} --testsuite "${{ inputs.test-testsuite }}"
+      run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml ${{ inputs.coverage == 'true' && '--coverage-cobertura coverage.xml' || '' }} ${{ inputs.phpunit-options }} --testsuite "${{ inputs.test-testsuite }}"
 
     - name: Run PHPUnit path
       if: ${{ inputs.test-path != '' }}
       shell: bash
-      run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml ${{ inputs.coverage == 'true' && '--coverage-cobertura coverage.xml' || '' }} -- tests/integration/${{ inputs.test-path }}
+      run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml ${{ inputs.coverage == 'true' && '--coverage-cobertura coverage.xml' || '' }} ${{ inputs.phpunit-options }} -- tests/integration/${{ inputs.test-path }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -427,7 +427,7 @@ jobs:
         uses: ./.github/actions/phpunit-prepare
         with:
           # PHPUnit 12 requires PHP 8.3+
-          php-version: "8.4"
+          php-version: "8.5"
           keep-composer-tools: "true"
           migration-coverage: ${{ matrix.suite == 'migration' }}
           force-phpunit-12: "true"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -314,14 +314,8 @@ jobs:
           - unit
           - migration
     env:
-      APP_ENV: test
-      DATABASE_URL: mysql://root@127.0.0.1:3306/root
-      APP_URL: http://localhost:8000
-      APP_SECRET: def00000bb5acb32b54ff8ee130270586eec0e878f7337dc7a837acc31d3ff00f93a56b595448b4b29664847dd51991b3314ff65aeeeb761a133b0ec0e070433bff08e48
-      OPENSEARCH_URL: 127.0.0.1:9200
-      ADMIN_OPENSEARCH_URL: 127.0.0.1:9200
-      BLUE_GREEN_DEPLOYMENT: 1
-      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+      # the shared test environment (APP_ENV, DATABASE_URL, APP_SECRET, ...) is exported by
+      # ./.github/actions/phpunit-prepare; only the matrix-specific part lives here
       FEATURE_ALL: ${{ matrix.suite == 'migration' && 'major' || '' }}
 
     services:
@@ -378,6 +372,82 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: junit-phpunit-${{ matrix.suite }}
+          path: junit.xml
+          # a job that fails before PHPUnit reports (setup, crash) has no junit.xml
+          if-no-files-found: ignore
+          overwrite: true
+
+  phpunit-12:
+    # PHPUnit 12 gate: runs the unit, migration and devops suites on PHPUnit 12 and
+    # tolerates no PHP or PHPUnit notices/warnings (see the --fail-on-* options below).
+    # Coverage stays on the PHPUnit 11 `phpunit` job above; this job gates the upgrade.
+    name: "PHPUnit 12 for ${{ matrix.suite }}"
+    needs:
+      - markdown-only-changes
+    if: ${{ needs.markdown-only-changes.outputs.docs_only != 'true' }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - unit
+          - migration
+          - devops
+    env:
+      # the shared test environment (APP_ENV, DATABASE_URL, APP_SECRET, ...) is exported by
+      # ./.github/actions/phpunit-prepare; only the matrix-specific part lives here
+      FEATURE_ALL: ${{ matrix.suite == 'migration' && 'major' || '' }}
+
+    services:
+      elasticsearch:
+        # no suite in this job talks to OpenSearch; the cheap placeholder keeps the port closed
+        image: alpine
+        env:
+          discovery.type: single-node
+          plugins.security.disabled: "true"
+          OPENSEARCH_INITIAL_ADMIN_PASSWORD: "yourStrongPassword123!"
+        ports:
+          - "9200:9200"
+      database:
+        # migration: MySQL 8.4 rejects foreign keys onto non-unique keys during install/migrate
+        # (restrict_fk_on_non_standard_key defaults to ON there); devops: NonStandardFkGuardTest
+        # skips without that default. The unit suite stays on MySQL 8.0.
+        image: ${{ matrix.suite == 'unit' && 'mysql:8.0' || 'mysql:8.4' }}
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+          MYSQL_DATABASE: shopware
+        ports:
+          - "3306:3306"
+        options: --health-cmd="mysqladmin ping || mariadb-admin ping"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup and install Shopware
+        uses: ./.github/actions/phpunit-prepare
+        with:
+          # PHPUnit 12 requires PHP 8.3+
+          php-version: "8.4"
+          keep-composer-tools: "true"
+          migration-coverage: ${{ matrix.suite == 'migration' }}
+          force-phpunit-12: "true"
+      - name: Install Danger # the unit tests for the Danger rules type against the danger-php package
+        if: ${{ matrix.suite == 'unit' }}
+        run: composer install -d vendor-bin/danger-php --no-interaction
+      - name: Run PHPUnit failing on notices and warnings
+        id: phpunit
+        uses: ./.github/actions/phpunit-run
+        with:
+          test-testsuite: ${{ matrix.suite }}
+          # coverage is collected but not uploaded: PHPUnit only validates #[CoversClass] targets
+          # ("is not a valid target for code coverage" PHPUnit warnings) while coverage is active
+          coverage: "true"
+          phpunit-options: "--display-phpunit-notices --fail-on-notice --fail-on-warning --fail-on-phpunit-notice --fail-on-phpunit-warning"
+      - name: Upload junit report for the failure tracking issue
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: junit-phpunit-12-${{ matrix.suite }}
           path: junit.xml
           # a job that fails before PHPUnit reports (setup, crash) has no junit.xml
           if-no-files-found: ignore
@@ -450,6 +520,7 @@ jobs:
       - phpstan
       - openapi-lint
       - phpunit
+      - phpunit-12
       - license-check
       - composer-audit
       - bc-checker
@@ -460,5 +531,5 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           # allowed-failures: docs, linters
-          allowed-skips: ${{ needs.markdown-only-changes.outputs.docs_only == 'true' && 'lint, phpstan, rector, openapi-lint, phpunit, license-check, composer-audit, bc-checker' || '' }}
+          allowed-skips: ${{ needs.markdown-only-changes.outputs.docs_only == 'true' && 'lint, phpstan, rector, openapi-lint, phpunit, phpunit-12, license-check, composer-audit, bc-checker' || '' }}
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -379,7 +379,7 @@ jobs:
 
   phpunit-12:
     # PHPUnit 12 gate: runs the unit, migration and devops suites on PHPUnit 12 and
-    # tolerates no PHP or PHPUnit notices/warnings (see the --fail-on-* options below).
+    # tolerates no PHPUnit notices/warnings; plain PHP notices and warnings stay tolerated.
     # Coverage stays on the PHPUnit 11 `phpunit` job above; this job gates the upgrade.
     name: "PHPUnit 12 for ${{ matrix.suite }}"
     needs:
@@ -442,7 +442,7 @@ jobs:
           # coverage is collected but not uploaded: PHPUnit only validates #[CoversClass] targets
           # ("is not a valid target for code coverage" PHPUnit warnings) while coverage is active
           coverage: "true"
-          phpunit-options: "--display-phpunit-notices --fail-on-notice --fail-on-warning --fail-on-phpunit-notice --fail-on-phpunit-warning"
+          phpunit-options: "--display-phpunit-notices --fail-on-phpunit-notice --fail-on-phpunit-warning"
       - name: Upload junit report for the failure tracking issue
         if: failure() && github.event_name == 'schedule'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
> Mirror of an upstream pull request, opened for automated review. **Do not merge.**

|  |  |
|---|---|
| Upstream | https://github.com/shopware/shopware/pull/20045 |
| Author | `@nfortier-shopware` |
| Base | `trunk` at merge-base `abc908dd0e56` |
| Head | `662685cc75b7` |

---

### Original description

### 1. Why is this change necessary?

PHPUnit 12 fails builds on PHPUnit notices and warnings that version 11 tolerates. The backlog is fixed in separate PRs; without a blocking lane it regrows before the version pin can be bumped.

### 2. What does this change do, exactly?

- Adds a blocking `phpunit-12` job to `php.yml`: unit, migration and devops suites on PHP 8.5 under `phpunit/phpunit:^12.4`, with coverage collection active (invalid covers targets only warn while coverage runs) and `--fail-on-phpunit-notice --fail-on-phpunit-warning` (plain PHP notices and warnings stay tolerated).
- `phpunit-prepare` exports the canonical test environment once and gains the PHPUnit 12 force step; `phpunit-run` passes the extra options through.
- The stock PHPUnit 11 jobs are unchanged.

### 3. Describe each step to reproduce the issue or behaviour.

⚠️ once https://github.com/shopware/shopware/pull/20047 is merged, this PR can fly, otherwise it will be constant failure

Run any suite under PHPUnit 12.4 with the fail flags: tolerated PHPUnit notices and warnings become failures.

### 4. Please link to the relevant issues (if any).

- relates `#17937`
- replaces `#17226`

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them



<!-- shopware-pr-mirror: upstream=shopware/shopware pr=20045 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated test coverage using PHPUnit 12 on PHP 8.5.
  * Expanded validation across unit, migration, and DevOps test suites.
  * Test runs now fail on PHPUnit notices and warnings for improved reliability.
  * Standardized shared test environment setup across workflows.
  * Added support for passing additional PHPUnit command-line options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->