### PR TITLE
[#20080] fix(administration): disabled entity-select clearing an unresolved bound value

### DIFF
--- a/changelog/_unreleased/2026-09-03-fix-disabled-entity-select-clearing-unresolved-value.md
+++ b/changelog/_unreleased/2026-09-03-fix-disabled-entity-select-clearing-unresolved-value.md
@@ -1,7 +1,0 @@
----
-title: Fix disabled sw-entity-single-select clearing an unresolved bound value
-author: Waqas Ahmed
-author_github: wakqasahmed
----
-# Administration
-* Fixed `sw-entity-single-select` emitting `update:value` with `null` when the bound entity can't be resolved under the passed criteria while the select is disabled, which could corrupt required order fields (see #20030)

--- a/changelog/_unreleased/2026-09-03-fix-disabled-entity-select-clearing-unresolved-value.md
+++ b/changelog/_unreleased/2026-09-03-fix-disabled-entity-select-clearing-unresolved-value.md
@@ -1,0 +1,7 @@
+---
+title: Fix disabled sw-entity-single-select clearing an unresolved bound value
+author: Waqas Ahmed
+author_github: wakqasahmed
+---
+# Administration
+* Fixed `sw-entity-single-select` emitting `update:value` with `null` when the bound entity can't be resolved under the passed criteria while the select is disabled, which could corrupt required order fields (see #20030)

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/index.js
@@ -298,7 +298,7 @@ export default {
                     ]),
                 )
                 .then((item) => {
-                    if (!item) {
+                    if (!item && !this.disabled) {
                         this.$emit('update:value', null);
                     }
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.spec.js
@@ -239,6 +239,34 @@ describe('components/sw-entity-single-select', () => {
         expect(singleSelection).toBeNull();
     });
 
+    it('does not clear an unresolved selection when disabled', async () => {
+        const repository = {
+            get: jest.fn().mockResolvedValue(null),
+        };
+        const wrapper = await createEntitySingleSelect({
+            props: {
+                value: 'unresolved-id',
+                disabled: true,
+            },
+            global: {
+                provide: {
+                    repositoryFactory: {
+                        create: () => repository,
+                    },
+                },
+            },
+        });
+        await flushPromises();
+
+        expect(repository.get).toHaveBeenCalledWith(
+            'unresolved-id',
+            expect.any(Object),
+            expect.any(Object),
+            undefined,
+        );
+        expect(wrapper.emitted('update:value')).toBeUndefined();
+    });
+
     it('should have disabled state results according to function', async () => {
         const wrapper = await createEntitySingleSelect({
             props: {

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.spec.js
@@ -258,12 +258,7 @@ describe('components/sw-entity-single-select', () => {
         });
         await flushPromises();
 
-        expect(repository.get).toHaveBeenCalledWith(
-            'unresolved-id',
-            expect.any(Object),
-            expect.any(Object),
-            undefined,
-        );
+        expect(repository.get).toHaveBeenCalledWith('unresolved-id', expect.any(Object), expect.any(Object), undefined);
         expect(wrapper.emitted('update:value')).toBeUndefined();
     });
 


### PR DESCRIPTION
> Mirror of an upstream pull request, opened for automated review. **Do not merge.**

|  |  |
|---|---|
| Upstream | https://github.com/shopware/shopware/pull/20080 |
| Author | `@wakqasahmed` |
| Base | `trunk` at merge-base `9ccb4b67b122` |
| Head | `8702c33d291c` |

---

### Original description

Fixes `#20030`.

`sw-entity-single-select`'s `loadSelected()` emitted `update:value` with `null` whenever the entity repository lookup couldn't resolve the bound ID under the passed criteria -- even when the select is disabled. In `sw-order-detail-details`, two disabled selects (`delivery.shippingMethodId`, `order.languageId`) are bound directly to `Required`-in-the-DAL order fields with a sales-channel-restricted criteria, so an order whose shipping method or language is no longer assigned to its sales channel gets those fields silently nulled just by opening the Details tab, and every following save fails with HTTP 400 ("This value should not be blank").

Fix: only emit the `null` when the select is not disabled. A disabled select can't let the user fix the selection anyway, so clearing a value the user never touched just corrupts data instead of surfacing anything actionable.

Added a unit test covering: when `disabled` is true and the criteria-restricted lookup resolves to nothing, the component does not emit `update:value`.

I don't have an internal NEXT- ticket for this (external contributor), so the changelog entry omits the `issue` field, matching other recent unreleased entries that also omit it.

I wasn't able to run the admin Jest suite in my environment, so I'd appreciate CI's read on the new test specifically.


<!-- shopware-pr-mirror: upstream=shopware/shopware pr=20080 -->

